### PR TITLE
Timeseries aggregation helper

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/montanaflynn/stats v0.7.1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	golang.org/x/net v0.10.0 // indirect
 	golang.org/x/oauth2 v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8eaE=
+github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=

--- a/indexers/factory.go
+++ b/indexers/factory.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The go-commons Authors.
+// Copyright 2023 The go-commons Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/indexers/types.go
+++ b/indexers/types.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The go-commons Authors.
+// Copyright 2023 The go-commons Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ocp-metadata/ocp-metadata.go
+++ b/ocp-metadata/ocp-metadata.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The go-commons Authors.
+// Copyright 2023 The go-commons Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -90,8 +90,7 @@ func (p *Prometheus) QueryRangeAggregatedTS(query string, start, end time.Time, 
 	var err error
 	var datapoints []float64
 	var result float64
-	r := apiv1.Range{Start: start, End: end, Step: step}
-	v, _, err := p.api.QueryRange(context.TODO(), query, r)
+	v, err := p.QueryRange(query, start, end, step)
 	if err != nil {
 		return result, err
 	}

--- a/prometheus/types.go
+++ b/prometheus/types.go
@@ -20,6 +20,19 @@ import (
 	apiv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 )
 
+type Aggregation string
+
+const (
+	Avg   Aggregation = "avg"
+	Max   Aggregation = "max"
+	Min   Aggregation = "min"
+	P99   Aggregation = "99"
+	P95   Aggregation = "95"
+	P90   Aggregation = "90"
+	P50   Aggregation = "50"
+	Stdev Aggregation = "stdev"
+)
+
 // Prometheus describes the prometheus connection
 type Prometheus struct {
 	api      apiv1.API

--- a/prometheus/types.go
+++ b/prometheus/types.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The go-commons Authors.
+// Copyright 2023 The go-commons Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Adding a simple method that returns the passed aggregation over a set of timeseries returned by `query`.

At the moment supporting:
- Max
- Min
- Avg
- Stdev
- P99, P95, P90, P90

Make me know if you're missing any aggregation