### PR TITLE
Add ocpMajorVersion field

### DIFF
--- a/ocp-metadata/ocp-metadata.go
+++ b/ocp-metadata/ocp-metadata.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -69,7 +70,7 @@ func (meta *Metadata) GetClusterMetadata() (ClusterMetadata, error) {
 	if err != nil {
 		return metadata, err
 	}
-	metadata.OCPVersion, metadata.K8SVersion = version.ocpVersion, version.k8sVersion
+	metadata.OCPVersion, metadata.OCPMajorVersion, metadata.K8SVersion = version.ocpVersion, version.ocpMajorVersion, version.k8sVersion
 	nodeInfo, err := meta.getNodesInfo()
 	if err != nil {
 		return metadata, err
@@ -205,6 +206,8 @@ func (meta *Metadata) getVersionInfo() (versionObj, error) {
 			break
 		}
 	}
+	shortReg, _ := regexp.Compile(`([0-9]\.[0-9]+)-*`)
+	versionInfo.ocpMajorVersion = shortReg.FindString(versionInfo.ocpVersion)
 	return versionInfo, err
 }
 

--- a/ocp-metadata/types.go
+++ b/ocp-metadata/types.go
@@ -53,8 +53,9 @@ type infraObj struct {
 
 // Type to store version info
 type versionObj struct {
-	ocpVersion string
-	k8sVersion string
+	ocpVersion      string
+	ocpMajorVersion string
+	k8sVersion      string
 }
 
 // Type to store cluster info
@@ -83,6 +84,7 @@ type ClusterMetadata struct {
 	MetricName       string `json:"metricName,omitempty"`
 	Platform         string `json:"platform"`
 	OCPVersion       string `json:"ocpVersion"`
+	OCPMajorVersion  string `json:"ocpMajorVersion`
 	K8SVersion       string `json:"k8sVersion"`
 	MasterNodesType  string `json:"masterNodesType"`
 	WorkerNodesType  string `json:"workerNodesType"`

--- a/ocp-metadata/types.go
+++ b/ocp-metadata/types.go
@@ -84,7 +84,7 @@ type ClusterMetadata struct {
 	MetricName       string `json:"metricName,omitempty"`
 	Platform         string `json:"platform"`
 	OCPVersion       string `json:"ocpVersion"`
-	OCPMajorVersion  string `json:"ocpMajorVersion`
+	OCPMajorVersion  string `json:"ocpMajorVersion"`
 	K8SVersion       string `json:"k8sVersion"`
 	MasterNodesType  string `json:"masterNodesType"`
 	WorkerNodesType  string `json:"workerNodesType"`


### PR DESCRIPTION
### Description

Based on the k8s-netperf logic. Field name is different though. Shall we rename it?
