### PR TITLE
Fix worker node count logic

### DIFF
--- a/ocp-metadata/ocp-metadata.go
+++ b/ocp-metadata/ocp-metadata.go
@@ -71,17 +71,9 @@ func (meta *Metadata) GetClusterMetadata() (ClusterMetadata, error) {
 		return metadata, err
 	}
 	metadata.OCPVersion, metadata.OCPMajorVersion, metadata.K8SVersion = version.ocpVersion, version.ocpMajorVersion, version.k8sVersion
-	nodeInfo, err := meta.getNodesInfo()
-	if err != nil {
+	if meta.getNodesInfo(&metadata) != nil {
 		return metadata, err
 	}
-	metadata.TotalNodes = nodeInfo.totalNodes
-	metadata.MasterNodesCount = nodeInfo.masterCount
-	metadata.WorkerNodesCount = nodeInfo.workerCount
-	metadata.InfraNodesCount = nodeInfo.infraCount
-	metadata.MasterNodesType = nodeInfo.masterType
-	metadata.WorkerNodesType = nodeInfo.workerType
-	metadata.InfraNodesType = nodeInfo.infraType
 	return metadata, err
 }
 
@@ -212,37 +204,29 @@ func (meta *Metadata) getVersionInfo() (versionObj, error) {
 }
 
 // getNodesInfo returns node information
-func (meta *Metadata) getNodesInfo() (nodeInfo, error) {
-	var nodeInfoData nodeInfo
+func (meta *Metadata) getNodesInfo(clusterMetadata *ClusterMetadata) error {
 	nodes, err := meta.clientSet.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return nodeInfoData, err
+		return err
 	}
-	nodeInfoData.totalNodes = len(nodes.Items)
-newNode:
+	clusterMetadata.TotalNodes = len(nodes.Items)
+	// When the master label is found, the node is considered a master, regarldess of other labels the node could have
+	// similar logic happens with the infra nodes
 	for _, node := range nodes.Items {
-		for k := range node.Labels {
-			switch k {
-			case "node-role.kubernetes.io/master":
-				nodeInfoData.masterCount++
-				nodeInfoData.masterType = node.Labels["node.kubernetes.io/instance-type"]
-			case "node-role.kubernetes.io/infra":
-				nodeInfoData.infraCount++
-				nodeInfoData.infraType = node.Labels["node.kubernetes.io/instance-type"]
-			case "node-role.kubernetes.io/worker":
-				// We iterate over all node labels, and if we detect that the node has an infra or workload label we skip it
-				// from the worker count
-				for label := range node.Labels {
-					if label == "node-role.kubernetes.io/infra" || label == "node-role.kubernetes.io/workload" {
-						continue newNode
-					}
-				}
-				nodeInfoData.workerType = node.Labels["node.kubernetes.io/instance-type"]
-				nodeInfoData.workerCount++
-			}
+		if _, ok := node.Labels["node-role.kubernetes.io/master"]; ok { // Check for master role
+			clusterMetadata.MasterNodesCount++
+			clusterMetadata.MasterNodesType = node.Labels["node.kubernetes.io/instance-type"]
+		} else if _, ok := node.Labels["node-role.kubernetes.io/infra"]; ok { // Check for infra role
+			clusterMetadata.InfraNodesCount++
+			clusterMetadata.InfraNodesType = node.Labels["node.kubernetes.io/instance-type"]
+		} else if _, ok := node.Labels["node-role.kubernetes.io/worker"]; ok { // Check for worker role
+			clusterMetadata.WorkerNodesCount++
+			clusterMetadata.WorkerNodesType = node.Labels["node.kubernetes.io/instance-type"]
+		} else {
+			clusterMetadata.OtherNodesCount++
 		}
 	}
-	return nodeInfoData, err
+	return err
 }
 
 // getSDNInfo returns SDN type

--- a/ocp-metadata/types.go
+++ b/ocp-metadata/types.go
@@ -68,17 +68,6 @@ type clusterVersion struct {
 	} `json:"status"`
 }
 
-// Type to store node info
-type nodeInfo struct {
-	workerCount int
-	infraCount  int
-	masterCount int
-	totalNodes  int
-	masterType  string
-	workerType  string
-	infraType   string
-}
-
 // Type to store cluster metadata
 type ClusterMetadata struct {
 	MetricName       string `json:"metricName,omitempty"`
@@ -92,6 +81,7 @@ type ClusterMetadata struct {
 	InfraNodesType   string `json:"infraNodesType"`
 	WorkerNodesCount int    `json:"workerNodesCount"`
 	InfraNodesCount  int    `json:"infraNodesCount"`
+	OtherNodesCount  int    `json:"otherNodesCount"`
 	TotalNodes       int    `json:"totalNodes"`
 	SDNType          string `json:"sdnType"`
 	ClusterName      string `json:"clusterName"`


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

The previous logic was counting nodes with the infra and worker labels (this happens in Classic ROSA clusters), as workers. With this patch, when the worker label is found, we ensure that the node does not contain any "workload" or "infra" label.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
