### PR TITLE
Use Prometheus bearer token only when provided

### DIFF
--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -31,7 +31,11 @@ func (bat authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if bat.username != "" {
 		req.SetBasicAuth(bat.username, bat.password)
 	}
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", bat.token))
+
+	if bat.token != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", bat.token))
+	}
+
 	return bat.Transport.RoundTrip(req)
 }
 

--- a/prometheus/prometheus_test.go
+++ b/prometheus/prometheus_test.go
@@ -1,6 +1,7 @@
 package prometheus
 
 import (
+	"encoding/base64"
 	"fmt"
 	"net/http"
 	"time"
@@ -29,6 +30,56 @@ var _ = Describe("Tests for Prometheus", func() {
 				return
 			}
 			_, err = bat.RoundTrip(req)
+			//Asserting no of times mocks are called
+			Expect(count).To(BeEquivalentTo(0))
+			Expect(err).To(BeNil())
+		})
+
+		It("Test2 bearer header is used when token is provided", func() {
+			url := "https://example.com/api"
+			req, err := http.NewRequest(http.MethodGet, url, nil)
+			if err != nil {
+				fmt.Println("Failed to create request:", err)
+				return
+			}
+			_, err = bat.RoundTrip(req)
+			Expect(req.Header.Get("Authorization")).To(Equal("Bearer someRandomToken"))
+			//Asserting no of times mocks are called
+			Expect(count).To(BeEquivalentTo(0))
+			Expect(err).To(BeNil())
+		})
+
+		It("Test3 basic auth header is used when no token is provided", func() {
+			bat.token = ""
+			url := "https://example.com/api"
+			req, err := http.NewRequest(http.MethodGet, url, nil)
+			if err != nil {
+				fmt.Println("Failed to create request:", err)
+				return
+			}
+			_, err = bat.RoundTrip(req)
+
+			encodedAuthHeader := base64.StdEncoding.EncodeToString([]byte("someRandomUsername:someRandomPassword"))
+
+			Expect(req.Header.Get("Authorization")).To(Equal("Basic " + encodedAuthHeader))
+			//Asserting no of times mocks are called
+			Expect(count).To(BeEquivalentTo(0))
+			Expect(err).To(BeNil())
+		})
+
+		It("Test4 no auth header set when auth details are omitted", func() {
+			bat.token = ""
+			bat.username = ""
+			bat.password = ""
+			url := "https://example.com/api"
+			req, err := http.NewRequest(http.MethodGet, url, nil)
+			if err != nil {
+				fmt.Println("Failed to create request:", err)
+				return
+			}
+			_, err = bat.RoundTrip(req)
+
+			Expect(req.Header.Get("Authorization")).To(Equal(""))
 			//Asserting no of times mocks are called
 			Expect(count).To(BeEquivalentTo(0))
 			Expect(err).To(BeNil())


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This library is used in `kube-burner`. `kube-burner`'s `init` command accepts `username`, `password` and `token` parameters for connecting to Prometheus. However, it is not possible to connect to Prometheus that is configured with username/password only because this library unconditionally sets the `Bearer` header, including with an empty `token`. This results in a 401 from the Prometheus client.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

## Testing
I tested this by building `kube-burner` with the proposed changes and seeing it successfully connect to my basic auth Prometheus.