### PR TITLE
Update verify connection API call

### DIFF
--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -88,9 +88,6 @@ func (p *Prometheus) QueryRange(query string, start, end time.Time, step time.Du
 
 // Verifies prometheus connection
 func (p *Prometheus) verifyConnection() error {
-	_, err := p.api.Runtimeinfo(context.TODO())
-	if err != nil {
-		return err
-	}
-	return nil
+	_, err := p.Query("up{}", time.Now().UTC().UTC())
+	return err
 }

--- a/prometheus/prometheus_test.go
+++ b/prometheus/prometheus_test.go
@@ -101,7 +101,7 @@ var _ = Describe("Tests for Prometheus", func() {
 			_, err := NewClient(url, token, username, password, tlsSkipVerify)
 			//Asserting no of times mocks are called
 			Expect(count).To(BeEquivalentTo(0))
-			Expect(err.Error()).To(ContainSubstring("Get \"/api/v1/status/runtimeinfo\": unsupported protocol scheme \"\""))
+			Expect(err.Error()).To(ContainSubstring("Post \"/api/v1/query\": unsupported protocol scheme \"\""))
 		})
 
 		It("Test2 passing not valid url", func() {


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The previous API call doesn't work in AKS's prometheus instances. Seems like endpoints from the /status path are not exposed

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
