### PR TITLE
Return a new indexer rather than a pointer to the same object

### DIFF
--- a/indexers/factory.go
+++ b/indexers/factory.go
@@ -18,20 +18,19 @@ import (
 	"fmt"
 )
 
-var indexerMap = make(map[IndexerType]Indexer)
-
 // NewIndexer creates a new Indexer with the specified IndexerConfig
 func NewIndexer(indexerConfig IndexerConfig) (*Indexer, error) {
 	var indexer Indexer
-	var exists bool
-	cfg := indexerConfig
-	if indexer, exists = indexerMap[cfg.Type]; exists {
-		err := indexer.new(indexerConfig)
-		if err != nil {
-			return &indexer, err
-		}
-	} else {
-		return &indexer, fmt.Errorf("Indexer not found: %s", cfg.Type)
+	var err error
+	switch indexerConfig.Type {
+	case LocalIndexer:
+		indexer, err = NewLocalIndexer(indexerConfig)
+	case ElasticIndexer:
+		indexer, err = NewElasticIndexer(indexerConfig)
+	case OpenSearchIndexer:
+		indexer, err = NewOpenSearchIndexer(indexerConfig)
+	default:
+		return &indexer, fmt.Errorf("Indexer not found: %s", indexerConfig.Type)
 	}
-	return &indexer, nil
+	return &indexer, err
 }

--- a/indexers/local.go
+++ b/indexers/local.go
@@ -26,19 +26,15 @@ type Local struct {
 	metricsDirectory string
 }
 
-// Init function
-func init() {
-	indexerMap[LocalIndexer] = &Local{}
-}
-
-// Prepares local indexing directory
-func (l *Local) new(indexerConfig IndexerConfig) error {
+// NewLocalIndexer returns a new Local Indexer
+func NewLocalIndexer(indexerConfig IndexerConfig) (*Local, error) {
+	var localIndexer Local
 	if indexerConfig.MetricsDirectory == "" {
-		return fmt.Errorf("directory name not specified")
+		return &localIndexer, fmt.Errorf("directory name not specified")
 	}
-	l.metricsDirectory = indexerConfig.MetricsDirectory
-	err := os.MkdirAll(l.metricsDirectory, 0744)
-	return err
+	localIndexer.metricsDirectory = indexerConfig.MetricsDirectory
+	err := os.MkdirAll(localIndexer.metricsDirectory, 0744)
+	return &localIndexer, err
 }
 
 // Index uses generates a local file with the given name and metrics

--- a/indexers/local_test.go
+++ b/indexers/local_test.go
@@ -18,7 +18,6 @@ var _ = Describe("Tests for local.go", func() {
 			indexerconfig IndexerConfig
 		}
 		var testcase newtestcase
-		var localIndexer Local
 		BeforeEach(func() {
 			testcase = newtestcase{
 				indexerconfig: IndexerConfig{Type: "local",
@@ -30,13 +29,13 @@ var _ = Describe("Tests for local.go", func() {
 		})
 
 		It("returns err no metrics directory", func() {
-			err := localIndexer.new(testcase.indexerconfig)
+			_, err := NewLocalIndexer(testcase.indexerconfig)
 			Expect(err).To(BeEquivalentTo(errors.New("directory name not specified")))
 		})
 
 		It("returns nil as error", func() {
 			testcase.indexerconfig.MetricsDirectory = "placeholder"
-			err := localIndexer.new(testcase.indexerconfig)
+			_, err := NewLocalIndexer(testcase.indexerconfig)
 			Expect(err).To(BeNil())
 		})
 	})

--- a/indexers/opensearch_test.go
+++ b/indexers/opensearch_test.go
@@ -2,10 +2,10 @@ package indexers
 
 import (
 	"errors"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"log"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -39,12 +39,12 @@ var _ = Describe("Tests for opensearch.go", func() {
 			}))
 			defer testcase.mockServer.Close()
 			testcase.indexerConfig.Servers = []string{testcase.mockServer.URL}
-			err := indexer.new(testcase.indexerConfig)
+			_, err := NewOpenSearchIndexer(testcase.indexerConfig)
 			Expect(err).To(BeEquivalentTo(errors.New("OpenSearch health check failed: cannot retrieve information from OpenSearch")))
 		})
 
 		It("when no url is passed", func() {
-			err := indexer.new(testcase.indexerConfig)
+			_, err := NewOpenSearchIndexer(testcase.indexerConfig)
 			testcase.mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusGatewayTimeout)
 			}))
@@ -56,7 +56,7 @@ var _ = Describe("Tests for opensearch.go", func() {
 			os.Setenv("ELASTICSEARCH_URL", "not a valid url:port")
 			defer os.Unsetenv("ELASTICSEARCH_URL")
 			defer testcase.mockServer.Close()
-			err := indexer.new(testcase.indexerConfig)
+			_, err := NewOpenSearchIndexer(testcase.indexerConfig)
 			Expect(err).To(BeEquivalentTo(errors.New("error creating the OpenSearch client: cannot create client: cannot parse url: parse \"not a valid url:port\": first path segment in URL cannot contain colon")))
 		})
 
@@ -64,7 +64,7 @@ var _ = Describe("Tests for opensearch.go", func() {
 			defer testcase.mockServer.Close()
 			testcase.indexerConfig.Servers = []string{testcase.mockServer.URL}
 			testcase.indexerConfig.Index = ""
-			err := indexer.new(testcase.indexerConfig)
+			_, err := NewOpenSearchIndexer(testcase.indexerConfig)
 			Expect(err).To(BeEquivalentTo(errors.New("index name not specified")))
 		})
 

--- a/indexers/types.go
+++ b/indexers/types.go
@@ -27,7 +27,6 @@ const (
 // Indexer interface
 type Indexer interface {
 	Index([]interface{}, IndexingOpts) (string, error)
-	new(IndexerConfig) error
 }
 
 // Indexing options


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

<!--- Describe your changes in detail -->

This change will permit creating multiple indexers of the same type

- Related Issue https://github.com/kube-burner/kube-burner-ocp/pull/56
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
