### PR TITLE
Adding verbose logging for indexing failures

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/opensearch-project/opensearch-go v1.1.0
 	github.com/prometheus/client_golang v1.15.1
 	github.com/prometheus/common v0.44.0
+	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.8.2
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.28.4

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ github.com/prometheus/common v0.44.0 h1:+5BrQJwiBB9xsMygAB3TNvpQKOwlkc25LbISbrdO
 github.com/prometheus/common v0.44.0/go.mod h1:ofAIvZbQ1e/nugmZGz4/qCb9Ap1VoSTIO7x0VV9VvuY=
 github.com/prometheus/procfs v0.9.0 h1:wzCHvIvM5SxWqYvwgVL7yJY8Lz3PKn49KQtpgMYJfhI=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
@@ -123,6 +125,7 @@ golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
 golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/indexers/factory_test.go
+++ b/indexers/factory_test.go
@@ -2,9 +2,9 @@ package indexers
 
 import (
 	"errors"
+	"log"
 	"net/http"
 	"net/http/httptest"
-	"log"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

Adding verbose logging so that we will get more details on indexing failures. For example
```
time="2024-10-25 19:46:56" level=info msg="Failed to index document 05401bfd49c03e4efc25f82f1e68bc5cf7bc51b370d95007ff9ebc4d54ea18c1: Could not dynamically add mapping for field [node.openshift.io/os_id]. Existing mapping for [labels.node] must be of type object but found [text]., error: <nil>" file="opensearch.go:127"
time="2024-10-25 19:46:56" level=info msg="Failed to index document 92e2d32943743936e999a74a7052f242b42165b812fa9c717193da81cf7091d6: Could not dynamically add mapping for field [node.openshift.io/os_id]. Existing mapping for [labels.node] must be of type object but found [text]., error: <nil>" file="opensearch.go:127"
time="2024-10-25 19:46:56" level=info msg="Failed to index document 1e368b19f8cb5b9ceced7f2a5773859b4b4b46a29ae4f0ef5c3cd81ee10d01cc: Could not dynamically add mapping for field [node.openshift.io/os_id]. Existing mapping for [labels.node] must be of type object but found [text]., error: <nil>" file="opensearch.go:127"
time="2024-10-25 19:46:56" level=info msg="Failed to index document 020c83478569c967ef35d44d0da59abcc9974d3765f7ae6403d1513262b63838: Could not dynamically add mapping for field [node.openshift.io/os_id]. Existing mapping for [labels.node] must be of type object but found [text]., error: <nil>" file="opensearch.go:127"
time="2024-10-25 19:46:56" level=info msg="Failed to index document f6aaa5f832d701f64689de3ac5b29caecf21af99aab25fcf8d9477a2cbca63ee: Could not dynamically add mapping for field [node.openshift.io/os_id]. Existing mapping for [labels.node] must be of type object but found [text]., error: <nil>" file="opensearch.go:127"
time="2024-10-25 19:46:56" level=info msg="Failed to index document b25e99a97b4a7401958c08ef4bd311962482afa63733b530ac0c8c09c4213b3d: Could not dynamically add mapping for field [node.openshift.io/os_id]. Existing mapping for [labels.node] must be of type object but found [text]., error: <nil>" file="opensearch.go:127"
time="2024-10-25 19:46:56" level=info msg="Failed to index document 2863cbec3da735b8d5d08d3ddd42d94ab8098a2ff36130113d7675c9826393b0: Could not dynamically add mapping for field [node.openshift.io/os_id]. Existing mapping for [labels.node] must be of type object but found [text]., error: <nil>" file="opensearch.go:127"
time="2024-10-25 19:46:56" level=info msg="Failed to index document 5a9b7064f69256fa4ba8c800a9ae2f166780578bec9040c0c4b87f09aae1d65c: Could not dynamically add mapping for field [node.openshift.io/os_id]. Existing mapping for [labels.node] must be of type object but found [text]., error: <nil>" file="opensearch.go:127"
time="2024-10-25 19:46:56" level=info msg="Failed to index document 53ffbd4e0c6dc9844264cfb923e6354793ed303b61f56a072d7a8b2f7f4950d4: Could not dynamically add mapping for field [node.openshift.io/os_id]. Existing mapping for [labels.node] must be of type object but found [text]., error: <nil>" file="opensearch.go:127"
time="2024-10-25 19:46:56" level=info msg="Failed to index document 7a1486babf2ec7d9d93ed8bca8b1ff82077513759da8f0b6e5d53d0c8c8a2ced: Could not dynamically add mapping for field [node.openshift.io/os_id]. Existing mapping for [labels.node] must be of type object but found [text]., error: <nil>" file="opensearch.go:127"
time="2024-10-25 19:46:56" level=info msg="Failed to index document 4b78cd70fdd47a92d4643d8d8ee3e3e212ccb29fdaf971617c3ee6e181fa4ec9: Could not dynamically add mapping for field [node.openshift.io/os_id]. Existing mapping for [labels.node] must be of type object but found [text]., error: <nil>" file="opensearch.go:127"
time="2024-10-25 19:46:56" level=info msg="Failed to index document 3b70cc8e29a1595b4b464edf6ac163ca331b57c7cfc1c3115a6c69b20ec28252: Could not dynamically add mapping for field [node.openshift.io/os_id]. Existing mapping for [labels.node] must be of type object but found [text]., error: <nil>" file="opensearch.go:127"
time="2024-10-25 19:46:56" level=info msg="Failed to index document 040059c1ab4206b4e2c13fbe169ce11c77968aa8e994481bf27322305d25b355: Could not dynamically add mapping for field [node.openshift.io/os_id]. Existing mapping for [labels.node] must be of type object but found [text]., error: <nil>" file="opensearch.go:127"
time="2024-10-25 19:46:56" level=info msg="Failed to index document 6a437b060809aad5b8995952710df24e0e36d922b2e82934c15e7f0fb6660bb0: Could not dynamically add mapping for field [node.openshift.io/os_id]. Existing mapping for [labels.node] must be of type object but found [text]., error: <nil>" file="opensearch.go:127"
time="2024-10-25 19:46:56" level=info msg="Failed to index document 12090bf0fe0eeb2ae7c1e36d5a52a5ef99432ce926fa6ccd28420686eaca9c27: Could not dynamically add mapping for field [node.openshift.io/os_id]. Existing mapping for [labels.node] must be of type object but found [text]., error: <nil>" file="opensearch.go:127"
time="2024-10-25 19:46:56" level=info msg="Failed to index document 5f0d2d17bceb354c329680c0822ed174af46bd5bed9486f925e0959abe5fecd8: Could not dynamically add mapping for field [node.openshift.io/os_id]. Existing mapping for [labels.node] must be of type object but found [text]., error: <nil>" file="opensearch.go:127"
time="2024-10-25 19:46:56" level=info msg="Failed to index document 6aa0c9403a99ebf9e7a12112109b6e95cb94ebdb0497f4fa2e79ddec37208741: Could not dynamically add mapping for field [node.openshift.io/os_id]. Existing mapping for [labels.node] must be of type object but found [text]., error: <nil>" file="opensearch.go:127"
time="2024-10-25 19:46:56" level=info msg="Failed to index document 23c6cc71463a2c68b17e92aea6a85c41f91f433d52003d9b84f5dbee7e32a577: Could not dynamically add mapping for field [node.openshift.io/os_id]. Existing mapping for [labels.node] must be of type object but found [text]., error: <nil>" file="opensearch.go:127"
time="2024-10-25 19:46:56" level=info msg="Failed to index document 32808fb9398af9b2c0d3627ef96e8bad144037e81c6be1231fb274322b5735ef: Could not dynamically add mapping for field [node.openshift.io/os_id]. Existing mapping for [labels.node] must be of type object but found [text]., error: <nil>" file="opensearch.go:127"
time="2024-10-25 19:46:57" level=info msg="Failed to index document bf51a75d5ca98f0877d09cf8e7b835fa0a4737f7920e2f2e8c8b5687a4339fc8: Could not dynamically add mapping for field [node.openshift.io/os_id]. Existing mapping for [labels.node] must be of type object but found [text]., error: <nil>" file="opensearch.go:127"
time="2024-10-25 19:46:57" level=info msg="Failed to index document 82ac8af1f1c5dee990bc0617e09bea0bd203fc73f4a0bfcb076a4eb222c2460a: Could not dynamically add mapping for field [node.openshift.io/os_id]. Existing mapping for [labels.node] must be of type object but found [text]., error: <nil>" file="opensearch.go:127"
time="2024-10-25 19:46:57" level=info msg="Indexing finished in 1.307s:" file="common.go:38"
```

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

## Testing
Tested integrating with kube-burner-ocp wrapper.