### PR TITLE
[PERFSCALE-3398] Ocp virt version

### DIFF
--- a/ocp-metadata/ocp-metadata.go
+++ b/ocp-metadata/ocp-metadata.go
@@ -397,7 +397,7 @@ func (meta *Metadata) GetOCPVirtualizationVersion() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if virtOpVers, ok := virtOp.Labels["app.kubernetes.io/verssion"]; ok {
+	if virtOpVers, ok := virtOp.Labels["app.kubernetes.io/version"]; ok {
 		return virtOpVers, nil
 	} else {
 		return "", fmt.Errorf("label app.kubernetes.io/version not found in virt-operator deployment")

--- a/ocp-metadata/ocp-metadata.go
+++ b/ocp-metadata/ocp-metadata.go
@@ -391,3 +391,15 @@ func toMap(str string) (map[string]interface{}, error) {
 	}
 	return config, nil
 }
+
+func (meta *Metadata) GetOCPVirtualizationVersion() (string, error) {
+	virtOp, err := meta.clientSet.AppsV1().Deployments("openshift-cnv").Get(context.TODO(), "virt-operator", metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	if virtOpVers, ok := virtOp.Labels["app.kubernetes.io/verssion"]; ok {
+		return virtOpVers, nil
+	} else {
+		return "", fmt.Errorf("label app.kubernetes.io/version not found in virt-operator deployment")
+	}
+}


### PR DESCRIPTION
## Type of change

- [x] Optimization

## Description

From the different alternatives to get the version I've tested, I think this one is the more reliable and simple.

Using the csv could work, but the name of the csv is not consistent, and changes with the deployed version, which makes the logic more complex:

```shell
 $ oc get csv -n openshift-cnv
NAME                                       DISPLAY                    VERSION   REPLACES                                   PHASE
kubevirt-hyperconverged-operator.v4.17.1   OpenShift Virtualization   4.17.1    kubevirt-hyperconverged-operator.v4.17.0   Succeeded
```

Something similar with the installplan

```shell
$ oc get installplan -A
NAMESPACE       NAME            CSV                                        APPROVAL    APPROVED
openshift-cnv   install-rhjt5   kubevirt-hyperconverged-operator.v4.17.1   Automatic   true

```