### PR TITLE
Fix incorrect GVR

### DIFF
--- a/ocp-metadata/ocp-metadata.go
+++ b/ocp-metadata/ocp-metadata.go
@@ -168,7 +168,7 @@ func (meta *Metadata) GetCurrentVMICount() (int, error) {
 
 // GetDefaultIngressDomain returns default ingress domain of the default ingress controller
 func (meta *Metadata) GetDefaultIngressDomain() (string, error) {
-	ingressController, err := meta.dynamicClient.Resource(routeGVR).
+	ingressController, err := meta.dynamicClient.Resource(ingressControllerGRV).
 		Namespace("openshift-ingress-operator").Get(context.TODO(), "default", metav1.GetOptions{})
 	if err != nil {
 		return "", err

--- a/ocp-metadata/types.go
+++ b/ocp-metadata/types.go
@@ -35,6 +35,12 @@ var routeGVR = schema.GroupVersionResource{
 	Resource: "routes",
 }
 
+var ingressControllerGRV = schema.GroupVersionResource{
+	Group:    "operator.openshift.io",
+	Version:  "v1",
+	Resource: "ingresscontrollers",
+}
+
 var vmiGVR = schema.GroupVersionResource{
 	Group:    "kubevirt.io",
 	Version:  "v1",


### PR DESCRIPTION
## Type of change

- [x] Bug fix

## Description

My bad, tt should be the ingress controller GVR rather than the route one

## Tests

cd-v2 works now
```shell
rsevilla@wonderland ~/labs/kube-burner-ocp (kube-burner-v1.11.3) $ git diff
diff --git a/go.mod b/go.mod
index e661644..1141207 100644
--- a/go.mod
+++ b/go.mod
@@ -88,3 +88,5 @@ require (
        sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
        sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/cloud-bulldozer/go-commons => /home/rsevilla/labs/go-commons/
diff --git a/go.sum b/go.sum
index a737f49..0a80129 100644
--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,6 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloud-bulldozer/go-commons v1.0.18 h1:MElT8YvyDJ9VQbdjLn3IBq8P/yZqKhZNO+HD0F202Lw=
-github.com/cloud-bulldozer/go-commons v1.0.18/go.mod h1:CKmdWhyxN6p4leLhdwKxQHJ3wiKNUistFKsctLTSqIk=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
rsevilla@wonderland ~/labs/kube-burner-ocp (kube-burner-v1.11.3) $ ./bin/amd64/kube-burner-ocp cluster-density-v2 --iterations=1
time="2024-12-12 11:37:16" level=info msg="❤️  Checking for Cluster Health" file="cluster_health.go:45"
time="2024-12-12 11:37:18" level=info msg="Cluster is Healthy" file="cluster_health.go:53"
time="2024-12-12 11:37:20" level=info msg="🔥 Starting kube-burner (kube-burner-v1.11.3@badcf628c8d565e90dda35b88e6bdaa5fd68d44c) with UUID dc2929de-3577-4320-8d8e-8fd7eb3ccfb3" file="job.go:82"
time="2024-12-12 11:37:20" level=info msg="📈 Registered measurement: podLatency" file="factory.go:95"
time="2024-12-12 11:37:20" level=info msg="QPS: 20" file="job.go:314"
time="2024-12-12 11:37:20" level=info msg="Burst: 20" file="job.go:315"
time="2024-12-12 11:37:21" level=info msg="Job cluster-density-v2: 1 iterations with 1 ImageStream replicas" file="create.go:88"
time="2024-12-12 11:37:21" level=info msg="Job cluster-density-v2: 1 iterations with 1 Build replicas" file="create.go:88"
time="2024-12-12 11:37:21" level=info msg="Job cluster-density-v2: 1 iterations with 5 Service replicas" file="create.go:88"
time="2024-12-12 11:37:21" level=info msg="Job cluster-density-v2: 1 iterations with 2 Route replicas" file="create.go:88"
time="2024-12-12 11:37:21" level=info msg="Job cluster-density-v2: 1 iterations with 10 Secret replicas" file="create.go:88"
time="2024-12-12 11:37:21" level=info msg="Job cluster-density-v2: 1 iterations with 10 ConfigMap replicas" file="create.go:88"
time="2024-12-12 11:37:21" level=info msg="Job cluster-density-v2: 1 iterations with 1 NetworkPolicy replicas" file="create.go:88"
time="2024-12-12 11:37:21" level=info msg="Job cluster-density-v2: 1 iterations with 1 NetworkPolicy replicas" file="create.go:88"
time="2024-12-12 11:37:21" level=info msg="Job cluster-density-v2: 1 iterations with 1 NetworkPolicy replicas" file="create.go:88"
time="2024-12-12 11:37:21" level=info msg="Job cluster-density-v2: 1 iterations with 3 Deployment replicas" file="create.go:88"
time="2024-12-12 11:37:21" level=info msg="Job cluster-density-v2: 1 iterations with 2 Deployment replicas" file="cr
``
