### PR TITLE
Method to return node allocatable resources

### DIFF
--- a/ocp-metadata/ocp-metadata.go
+++ b/ocp-metadata/ocp-metadata.go
@@ -142,6 +142,28 @@ func (meta *Metadata) GetCurrentPodCount(nodeLabelSelector string) (int, error) 
 	return podCount, nil
 }
 
+// GetAggregatedNodeCapacity returns the aggregated allocatable resources of nodes matching the given label selector
+func (meta *Metadata) GetAggNodeResources(nodeLabelSelector string) (NodeResources, error) {
+	var nodeResources NodeResources
+	nodeList, err := meta.connector.ClientSet().CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: nodeLabelSelector})
+	if err != nil {
+		return nodeResources, err
+	}
+	nodeResources.NodeCount = len(nodeList.Items)
+	for _, node := range nodeList.Items {
+		if cpuQuantity, ok := node.Status.Allocatable["cpu"]; ok {
+			nodeResources.CPUMilliCores += cpuQuantity.MilliValue() / 1000
+		}
+		if memoryQuantity, ok := node.Status.Allocatable["memory"]; ok {
+			nodeResources.MemoryBytes += memoryQuantity.Value()
+		}
+		if podQuantity, ok := node.Status.Allocatable["pods"]; ok {
+			nodeResources.PodCapacity += podQuantity.Value()
+		}
+	}
+	return nodeResources, nil
+}
+
 // Returns the number of current running VMIs in the cluster
 func (meta *Metadata) GetCurrentVMICount() (int, error) {
 	var vmiCount int

--- a/ocp-metadata/types.go
+++ b/ocp-metadata/types.go
@@ -88,6 +88,14 @@ type clusterVersion struct {
 	} `json:"status"`
 }
 
+// Type to store aggregated node capacity
+type NodeResources struct {
+	CPUMilliCores int64
+	MemoryBytes   int64
+	PodCapacity   int64
+	NodeCount     int
+}
+
 // Type to store cluster metadata
 type ClusterMetadata struct {
 	MetricName       string `json:"metricName,omitempty"`


### PR DESCRIPTION
## Type of change

- [x] New feature

## Description

New method to return the aggregated amount of allocatable resources across nodes matching a labelSelector. The idea is to potentially take advantage of this method to be able to allocate a certain % of resources when running a workload.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added aggregated node resource reporting based on label selectors.
  * Reports total CPU, memory, pod capacity, and node count for matching Kubernetes nodes.
  * Provides clear errors when node resource information cannot be retrieved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->