### PR TITLE
Updating local indexers to update data to existing files

### DIFF
--- a/indexers/local.go
+++ b/indexers/local.go
@@ -47,14 +47,20 @@ func (l *Local) Index(documents []interface{}, opts IndexingOpts) (string, error
 	}
 	metricName := fmt.Sprintf("%s.json", opts.MetricName)
 	filename := path.Join(l.metricsDirectory, metricName)
-	f, err := os.Create(filename)
-	if err != nil {
-		return "", fmt.Errorf("Error creating metrics file %s: %s", filename, err)
+	if content, err := os.ReadFile(filename); err == nil {
+		var existingDocs []interface{}
+		if err := json.Unmarshal(content, &existingDocs); err != nil {
+			return "", fmt.Errorf("JSON decoding error in %s: %s", filename, err)
+		}
+		documents = append(existingDocs, documents...)
 	}
-	defer f.Close()
-	jsonEnc := json.NewEncoder(f)
-	if err := jsonEnc.Encode(documents); err != nil {
+
+	content, err := json.Marshal(documents)
+	if err != nil {
 		return "", fmt.Errorf("JSON encoding error: %s", err)
 	}
-	return fmt.Sprintf("File %s created with %d documents", filename, len(documents)), nil
+	if err := os.WriteFile(filename, content, 0644); err != nil {
+		return "", fmt.Errorf("Error writing metrics file %s: %s", filename, err)
+	}
+	return fmt.Sprintf("File %s now contains %d documents", filename, len(documents)), nil
 }

--- a/indexers/local_test.go
+++ b/indexers/local_test.go
@@ -1,6 +1,7 @@
 package indexers
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -95,7 +96,7 @@ var _ = Describe("Tests for local.go", func() {
 		It("Err is returned metricsdirectory has fault", func() {
 			indexer.metricsDirectory = "abc"
 			_, err := indexer.Index(testcase.documents, testcase.opts)
-			Expect(err).To(BeEquivalentTo(errors.New("Error creating metrics file abc/placeholder.json: open abc/placeholder.json: no such file or directory")))
+			Expect(err).To(MatchError(errors.New("Error writing metrics file abc/placeholder.json: open abc/placeholder.json: no such file or directory")))
 		})
 
 		It("Err is returned by documents not processed", func() {
@@ -105,7 +106,43 @@ var _ = Describe("Tests for local.go", func() {
 		})
 		It("returns err no empty document list", func() {
 			_, err := indexer.Index(emtpyTestCase.documents, emtpyTestCase.opts)
-			Expect(err).To(BeEquivalentTo(fmt.Errorf("Empty document list in %v", emtpyTestCase.opts.MetricName)))
+			Expect(err).To(MatchError(fmt.Errorf("Empty document list in %v", emtpyTestCase.opts.MetricName)))
+		})
+
+		It("returns err when MetricName is empty", func() {
+			testcase.opts.MetricName = ""
+			_, err := indexer.Index(testcase.documents, testcase.opts)
+			Expect(err).To(MatchError(errors.New("MetricName shouldn't be empty")))
+		})
+
+		It("appends documents to existing metric file", func() {
+			existingDocs := []interface{}{"old-doc", map[string]interface{}{"key": "value"}}
+			content, err := json.Marshal(existingDocs)
+			Expect(err).To(BeNil())
+
+			filename := path.Join(indexer.metricsDirectory, testcase.opts.MetricName+".json")
+			err = os.WriteFile(filename, content, 0644)
+			Expect(err).To(BeNil())
+
+			_, err = indexer.Index(testcase.documents, testcase.opts)
+			Expect(err).To(BeNil())
+
+			updatedContent, err := os.ReadFile(filename)
+			Expect(err).To(BeNil())
+
+			var updatedDocs []interface{}
+			err = json.Unmarshal(updatedContent, &updatedDocs)
+			Expect(err).To(BeNil())
+			Expect(len(updatedDocs)).To(Equal(len(existingDocs) + len(testcase.documents)))
+		})
+
+		It("returns err when existing metric file has invalid JSON", func() {
+			filename := path.Join(indexer.metricsDirectory, testcase.opts.MetricName+".json")
+			err := os.WriteFile(filename, []byte("not-json"), 0644)
+			Expect(err).To(BeNil())
+
+			_, err = indexer.Index(testcase.documents, testcase.opts)
+			Expect(err).To(MatchError(errors.New("JSON decoding error in abc/placeholder.json: invalid character 'o' in literal null (expecting 'u')")))
 		})
 	})
 })


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [x] New feature
- [x] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description
Enables all the step run metircs to get append to the same existing files in local indexing: https://github.com/kube-burner/kube-burner/pull/1150 

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

## Testing
Tested and verified in local through `make unit-test` and by vendoring in this PR: https://github.com/kube-burner/kube-burner/pull/1150. Please look at the local indexing zip file in description.
