### PR TITLE
Add MicroShift metadata support

### DIFF
--- a/ocp-metadata/microshift.go
+++ b/ocp-metadata/microshift.go
@@ -47,15 +47,6 @@ type microShiftVersionInfo struct {
 var microShiftMajorMinorRe = regexp.MustCompile(`^[0-9]+\.[0-9]+`)
 
 func (meta *Metadata) detectDistribution() (string, microShiftVersionInfo, error) {
-	groups, err := meta.connector.ClientSet().Discovery().ServerGroups()
-	if err != nil {
-		return DistributionKubernetes, microShiftVersionInfo{}, err
-	}
-	apiGroups := make(map[string]bool, len(groups.Groups))
-	for _, group := range groups.Groups {
-		apiGroups[group.Name] = true
-	}
-
 	cm, err := meta.readMicroShiftVersionConfigMap()
 	switch {
 	case err == nil:
@@ -65,6 +56,15 @@ func (meta *Metadata) detectDistribution() (string, microShiftVersionInfo, error
 		// Expected on OpenShift and vanilla Kubernetes.
 	default:
 		// Keep metadata collection best-effort when kube-public is unreadable.
+	}
+
+	groups, err := meta.connector.ClientSet().Discovery().ServerGroups()
+	if err != nil {
+		return DistributionKubernetes, microShiftVersionInfo{}, err
+	}
+	apiGroups := make(map[string]bool, len(groups.Groups))
+	for _, group := range groups.Groups {
+		apiGroups[group.Name] = true
 	}
 
 	if apiGroups[apiGroupOpenShiftConfig] {

--- a/ocp-metadata/microshift.go
+++ b/ocp-metadata/microshift.go
@@ -1,0 +1,97 @@
+// Copyright 2026 The go-commons Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocpmetadata
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	microShiftVersionNamespace = "kube-public"
+	microShiftVersionConfigMap = "microshift-version"
+
+	apiGroupOpenShiftConfig = "config.openshift.io"
+	apiGroupOpenShiftRoute  = "route.openshift.io"
+
+	// DistributionKubernetes identifies a vanilla Kubernetes cluster.
+	DistributionKubernetes = "kubernetes"
+	// DistributionOpenShift identifies an OpenShift cluster.
+	DistributionOpenShift = "openshift"
+	// DistributionMicroShift identifies a MicroShift cluster.
+	DistributionMicroShift = "microshift"
+)
+
+type microShiftVersionInfo struct {
+	version    string
+	majorMinor string
+}
+
+var microShiftMajorMinorRe = regexp.MustCompile(`^[0-9]+\.[0-9]+`)
+
+func (meta *Metadata) detectDistribution() (string, microShiftVersionInfo, error) {
+	groups, err := meta.connector.ClientSet().Discovery().ServerGroups()
+	if err != nil {
+		return DistributionKubernetes, microShiftVersionInfo{}, err
+	}
+	apiGroups := make(map[string]bool, len(groups.Groups))
+	for _, group := range groups.Groups {
+		apiGroups[group.Name] = true
+	}
+
+	cm, err := meta.readMicroShiftVersionConfigMap()
+	switch {
+	case err == nil:
+		info, _ := parseMicroShiftVersion(cm)
+		return DistributionMicroShift, info, nil
+	case apierrors.IsNotFound(err):
+		// Expected on OpenShift and vanilla Kubernetes.
+	default:
+		// Keep metadata collection best-effort when kube-public is unreadable.
+	}
+
+	if apiGroups[apiGroupOpenShiftConfig] {
+		return DistributionOpenShift, microShiftVersionInfo{}, nil
+	}
+	if apiGroups[apiGroupOpenShiftRoute] {
+		return DistributionMicroShift, microShiftVersionInfo{}, nil
+	}
+	return DistributionKubernetes, microShiftVersionInfo{}, nil
+}
+
+func (meta *Metadata) readMicroShiftVersionConfigMap() (*corev1.ConfigMap, error) {
+	return meta.connector.ClientSet().CoreV1().ConfigMaps(microShiftVersionNamespace).Get(context.TODO(), microShiftVersionConfigMap, metav1.GetOptions{})
+}
+
+func parseMicroShiftVersion(cm *corev1.ConfigMap) (microShiftVersionInfo, error) {
+	version := cm.Data["version"]
+	if version == "" {
+		return microShiftVersionInfo{}, fmt.Errorf("%s/%s ConfigMap has no version field", microShiftVersionNamespace, microShiftVersionConfigMap)
+	}
+	info := microShiftVersionInfo{version: version}
+	major := cm.Data["major"]
+	minor := cm.Data["minor"]
+	if major != "" && minor != "" {
+		info.majorMinor = major + "." + minor
+	} else {
+		info.majorMinor = microShiftMajorMinorRe.FindString(version)
+	}
+	return info, nil
+}

--- a/ocp-metadata/microshift_test.go
+++ b/ocp-metadata/microshift_test.go
@@ -1,0 +1,207 @@
+// Copyright 2026 The go-commons Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocpmetadata
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+)
+
+type fakeConnector struct {
+	clientSet     kubernetes.Interface
+	dynamicClient dynamic.Interface
+	restConfig    *rest.Config
+}
+
+func (f fakeConnector) ClientSet() kubernetes.Interface {
+	return f.clientSet
+}
+
+func (f fakeConnector) RestConfig() *rest.Config {
+	return f.restConfig
+}
+
+func (f fakeConnector) DynamicClient() dynamic.Interface {
+	return f.dynamicClient
+}
+
+func TestDetectDistribution(t *testing.T) {
+	tests := []struct {
+		name             string
+		apiGroups        []string
+		configMapData    map[string]string
+		wantDistribution string
+		wantVersion      string
+		wantMajorMinor   string
+	}{
+		{
+			name:      "microshift configmap with version fields",
+			apiGroups: []string{apiGroupOpenShiftRoute},
+			configMapData: map[string]string{
+				"version": "4.22.0~rc.2",
+				"major":   "4",
+				"minor":   "22",
+			},
+			wantDistribution: DistributionMicroShift,
+			wantVersion:      "4.22.0~rc.2",
+			wantMajorMinor:   "4.22",
+		},
+		{
+			name: "microshift configmap with version only",
+			configMapData: map[string]string{
+				"version": "4.22.0~rc.2",
+			},
+			wantDistribution: DistributionMicroShift,
+			wantVersion:      "4.22.0~rc.2",
+			wantMajorMinor:   "4.22",
+		},
+		{
+			name:             "malformed microshift configmap still detects microshift",
+			configMapData:    map[string]string{"major": "4", "minor": "22"},
+			wantDistribution: DistributionMicroShift,
+		},
+		{
+			name:             "microshift route without config heuristic",
+			apiGroups:        []string{apiGroupOpenShiftRoute},
+			wantDistribution: DistributionMicroShift,
+		},
+		{
+			name:             "openshift",
+			apiGroups:        []string{apiGroupOpenShiftConfig, apiGroupOpenShiftRoute},
+			wantDistribution: DistributionOpenShift,
+		},
+		{
+			name:             "microshift configmap wins over openshift api",
+			apiGroups:        []string{apiGroupOpenShiftConfig, apiGroupOpenShiftRoute},
+			configMapData:    map[string]string{"version": "4.22.0~rc.2", "major": "4", "minor": "22"},
+			wantDistribution: DistributionMicroShift,
+			wantVersion:      "4.22.0~rc.2",
+			wantMajorMinor:   "4.22",
+		},
+		{
+			name:             "kubernetes",
+			wantDistribution: DistributionKubernetes,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			meta := newTestMetadata(t, tt.apiGroups, tt.configMapData)
+			gotDistribution, gotVersion, err := meta.detectDistribution()
+			if err != nil {
+				t.Fatalf("detectDistribution returned unexpected error: %v", err)
+			}
+			if gotDistribution != tt.wantDistribution {
+				t.Fatalf("distribution = %q, want %q", gotDistribution, tt.wantDistribution)
+			}
+			if gotVersion.version != tt.wantVersion {
+				t.Fatalf("version = %q, want %q", gotVersion.version, tt.wantVersion)
+			}
+			if gotVersion.majorMinor != tt.wantMajorMinor {
+				t.Fatalf("majorMinor = %q, want %q", gotVersion.majorMinor, tt.wantMajorMinor)
+			}
+		})
+	}
+}
+
+func TestGetClusterMetadataMicroShift(t *testing.T) {
+	meta := newTestMetadata(t, []string{apiGroupOpenShiftRoute}, map[string]string{
+		"version": "4.22.0~rc.2",
+		"major":   "4",
+		"minor":   "22",
+	})
+
+	clusterMetadata, err := meta.GetClusterMetadata()
+	if err != nil {
+		t.Fatalf("GetClusterMetadata returned unexpected error: %v", err)
+	}
+	if clusterMetadata.Distribution != DistributionMicroShift {
+		t.Fatalf("Distribution = %q, want %q", clusterMetadata.Distribution, DistributionMicroShift)
+	}
+	if !clusterMetadata.MicroShift {
+		t.Fatal("MicroShift = false, want true")
+	}
+	if clusterMetadata.MicroShiftVersion != "4.22.0~rc.2" {
+		t.Fatalf("MicroShiftVersion = %q, want %q", clusterMetadata.MicroShiftVersion, "4.22.0~rc.2")
+	}
+	if clusterMetadata.MicroShiftMajorVersion != "4.22" {
+		t.Fatalf("MicroShiftMajorVersion = %q, want %q", clusterMetadata.MicroShiftMajorVersion, "4.22")
+	}
+	if clusterMetadata.K8SVersion != "v1.35.3" {
+		t.Fatalf("K8SVersion = %q, want %q", clusterMetadata.K8SVersion, "v1.35.3")
+	}
+	if clusterMetadata.TotalNodes != 1 {
+		t.Fatalf("TotalNodes = %d, want %d", clusterMetadata.TotalNodes, 1)
+	}
+}
+
+func newTestMetadata(t *testing.T, apiGroups []string, configMapData map[string]string) Metadata {
+	t.Helper()
+
+	objects := []runtime.Object{
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "microshift",
+				Labels: map[string]string{
+					"node-role.kubernetes.io/master": "",
+					"node-role.kubernetes.io/worker": "",
+				},
+			},
+		},
+	}
+	if configMapData != nil {
+		objects = append(objects, newMicroShiftVersionConfigMap(configMapData))
+	}
+
+	clientSet := k8sfake.NewClientset(objects...)
+	discovery, ok := clientSet.Discovery().(*fake.FakeDiscovery)
+	if !ok {
+		t.Fatal("unexpected discovery type")
+	}
+	discovery.FakedServerVersion = &version.Info{GitVersion: "v1.35.3"}
+	for _, group := range apiGroups {
+		discovery.Resources = append(discovery.Resources, &metav1.APIResourceList{
+			GroupVersion: group + "/v1",
+		})
+	}
+
+	return Metadata{
+		connector: fakeConnector{
+			clientSet:     clientSet,
+			dynamicClient: dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()),
+			restConfig:    &rest.Config{},
+		},
+	}
+}
+
+func newMicroShiftVersionConfigMap(data map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: microShiftVersionNamespace,
+			Name:      microShiftVersionConfigMap,
+		},
+		Data: data,
+	}
+}

--- a/ocp-metadata/microshift_test.go
+++ b/ocp-metadata/microshift_test.go
@@ -194,6 +194,7 @@ func TestGetClusterMetadataMicroShift(t *testing.T) {
 	if clusterMetadata.TotalNodes != 1 {
 		t.Fatalf("TotalNodes = %d, want %d", clusterMetadata.TotalNodes, 1)
 	}
+	assertEmptyOpenShiftMetadata(t, clusterMetadata)
 }
 
 func TestGetClusterMetadataOpenShift(t *testing.T) {
@@ -209,6 +210,7 @@ func TestGetClusterMetadataOpenShift(t *testing.T) {
 	if clusterMetadata.MicroShift {
 		t.Fatal("MicroShift = true, want false")
 	}
+	assertEmptyMicroShiftMetadata(t, clusterMetadata)
 	if clusterMetadata.OCPVersion != "4.18.9" {
 		t.Fatalf("OCPVersion = %q, want %q", clusterMetadata.OCPVersion, "4.18.9")
 	}
@@ -259,6 +261,61 @@ func TestGetClusterMetadataOpenShift(t *testing.T) {
 	}
 	if clusterMetadata.WorkerNodesCount != 1 {
 		t.Fatalf("WorkerNodesCount = %d, want %d", clusterMetadata.WorkerNodesCount, 1)
+	}
+}
+
+func assertEmptyOpenShiftMetadata(t *testing.T, clusterMetadata ClusterMetadata) {
+	t.Helper()
+
+	if clusterMetadata.OCPVersion != "" {
+		t.Fatalf("OCPVersion = %q, want empty", clusterMetadata.OCPVersion)
+	}
+	if clusterMetadata.OCPMajorVersion != "" {
+		t.Fatalf("OCPMajorVersion = %q, want empty", clusterMetadata.OCPMajorVersion)
+	}
+	if clusterMetadata.Platform != "" {
+		t.Fatalf("Platform = %q, want empty", clusterMetadata.Platform)
+	}
+	if clusterMetadata.ClusterType != "" {
+		t.Fatalf("ClusterType = %q, want empty", clusterMetadata.ClusterType)
+	}
+	if clusterMetadata.Region != "" {
+		t.Fatalf("Region = %q, want empty", clusterMetadata.Region)
+	}
+	if clusterMetadata.ClusterName != "" {
+		t.Fatalf("ClusterName = %q, want empty", clusterMetadata.ClusterName)
+	}
+	if clusterMetadata.SDNType != "" {
+		t.Fatalf("SDNType = %q, want empty", clusterMetadata.SDNType)
+	}
+	if clusterMetadata.Fips {
+		t.Fatal("Fips = true, want false")
+	}
+	if clusterMetadata.Publish != "" {
+		t.Fatalf("Publish = %q, want empty", clusterMetadata.Publish)
+	}
+	if clusterMetadata.WorkerArch != "" {
+		t.Fatalf("WorkerArch = %q, want empty", clusterMetadata.WorkerArch)
+	}
+	if clusterMetadata.ControlPlaneArch != "" {
+		t.Fatalf("ControlPlaneArch = %q, want empty", clusterMetadata.ControlPlaneArch)
+	}
+	if clusterMetadata.Ipsec {
+		t.Fatal("Ipsec = true, want false")
+	}
+	if clusterMetadata.IpsecMode != "" {
+		t.Fatalf("IpsecMode = %q, want empty", clusterMetadata.IpsecMode)
+	}
+}
+
+func assertEmptyMicroShiftMetadata(t *testing.T, clusterMetadata ClusterMetadata) {
+	t.Helper()
+
+	if clusterMetadata.MicroShiftVersion != "" {
+		t.Fatalf("MicroShiftVersion = %q, want empty", clusterMetadata.MicroShiftVersion)
+	}
+	if clusterMetadata.MicroShiftMajorVersion != "" {
+		t.Fatalf("MicroShiftMajorVersion = %q, want empty", clusterMetadata.MicroShiftMajorVersion)
 	}
 }
 

--- a/ocp-metadata/microshift_test.go
+++ b/ocp-metadata/microshift_test.go
@@ -15,6 +15,7 @@
 package ocpmetadata
 
 import (
+	"errors"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -27,6 +28,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 type fakeConnector struct {
@@ -52,9 +54,11 @@ func TestDetectDistribution(t *testing.T) {
 		name             string
 		apiGroups        []string
 		configMapData    map[string]string
+		discoveryError   bool
 		wantDistribution string
 		wantVersion      string
 		wantMajorMinor   string
+		wantErr          bool
 	}{
 		{
 			name:      "microshift configmap with version fields",
@@ -101,6 +105,19 @@ func TestDetectDistribution(t *testing.T) {
 			wantMajorMinor:   "4.22",
 		},
 		{
+			name:             "microshift configmap works when discovery fails",
+			configMapData:    map[string]string{"version": "4.22.0~rc.2", "major": "4", "minor": "22"},
+			discoveryError:   true,
+			wantDistribution: DistributionMicroShift,
+			wantVersion:      "4.22.0~rc.2",
+			wantMajorMinor:   "4.22",
+		},
+		{
+			name:           "discovery error without microshift configmap returns error",
+			discoveryError: true,
+			wantErr:        true,
+		},
+		{
 			name:             "kubernetes",
 			wantDistribution: DistributionKubernetes,
 		},
@@ -109,7 +126,16 @@ func TestDetectDistribution(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			meta := newTestMetadata(t, tt.apiGroups, tt.configMapData)
+			if tt.discoveryError {
+				injectDiscoveryError(t, meta)
+			}
 			gotDistribution, gotVersion, err := meta.detectDistribution()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("detectDistribution returned nil error, want error")
+				}
+				return
+			}
 			if err != nil {
 				t.Fatalf("detectDistribution returned unexpected error: %v", err)
 			}
@@ -124,6 +150,18 @@ func TestDetectDistribution(t *testing.T) {
 			}
 		})
 	}
+}
+
+func injectDiscoveryError(t *testing.T, meta Metadata) {
+	t.Helper()
+
+	clientSet, ok := meta.connector.ClientSet().(*k8sfake.Clientset)
+	if !ok {
+		t.Fatal("unexpected clientset type")
+	}
+	clientSet.PrependReactor("get", "group", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("discovery failed")
+	})
 }
 
 func TestGetClusterMetadataMicroShift(t *testing.T) {

--- a/ocp-metadata/microshift_test.go
+++ b/ocp-metadata/microshift_test.go
@@ -20,6 +20,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/discovery/fake"
@@ -195,6 +196,72 @@ func TestGetClusterMetadataMicroShift(t *testing.T) {
 	}
 }
 
+func TestGetClusterMetadataOpenShift(t *testing.T) {
+	meta := newOpenShiftTestMetadata(t)
+
+	clusterMetadata, err := meta.GetClusterMetadata()
+	if err != nil {
+		t.Fatalf("GetClusterMetadata returned unexpected error: %v", err)
+	}
+	if clusterMetadata.Distribution != DistributionOpenShift {
+		t.Fatalf("Distribution = %q, want %q", clusterMetadata.Distribution, DistributionOpenShift)
+	}
+	if clusterMetadata.MicroShift {
+		t.Fatal("MicroShift = true, want false")
+	}
+	if clusterMetadata.OCPVersion != "4.18.9" {
+		t.Fatalf("OCPVersion = %q, want %q", clusterMetadata.OCPVersion, "4.18.9")
+	}
+	if clusterMetadata.OCPMajorVersion != "4.18" {
+		t.Fatalf("OCPMajorVersion = %q, want %q", clusterMetadata.OCPMajorVersion, "4.18")
+	}
+	if clusterMetadata.K8SVersion != "v1.31.6" {
+		t.Fatalf("K8SVersion = %q, want %q", clusterMetadata.K8SVersion, "v1.31.6")
+	}
+	if clusterMetadata.ClusterName != "ocp-test-abcde" {
+		t.Fatalf("ClusterName = %q, want %q", clusterMetadata.ClusterName, "ocp-test-abcde")
+	}
+	if clusterMetadata.Platform != "AWS" {
+		t.Fatalf("Platform = %q, want %q", clusterMetadata.Platform, "AWS")
+	}
+	if clusterMetadata.ClusterType != "rosa" {
+		t.Fatalf("ClusterType = %q, want %q", clusterMetadata.ClusterType, "rosa")
+	}
+	if clusterMetadata.Region != "us-east-1" {
+		t.Fatalf("Region = %q, want %q", clusterMetadata.Region, "us-east-1")
+	}
+	if clusterMetadata.SDNType != "OVNKubernetes" {
+		t.Fatalf("SDNType = %q, want %q", clusterMetadata.SDNType, "OVNKubernetes")
+	}
+	if !clusterMetadata.Fips {
+		t.Fatal("Fips = false, want true")
+	}
+	if clusterMetadata.Publish != "External" {
+		t.Fatalf("Publish = %q, want %q", clusterMetadata.Publish, "External")
+	}
+	if clusterMetadata.WorkerArch != "amd64" {
+		t.Fatalf("WorkerArch = %q, want %q", clusterMetadata.WorkerArch, "amd64")
+	}
+	if clusterMetadata.ControlPlaneArch != "amd64" {
+		t.Fatalf("ControlPlaneArch = %q, want %q", clusterMetadata.ControlPlaneArch, "amd64")
+	}
+	if !clusterMetadata.Ipsec {
+		t.Fatal("Ipsec = false, want true")
+	}
+	if clusterMetadata.IpsecMode != "Full" {
+		t.Fatalf("IpsecMode = %q, want %q", clusterMetadata.IpsecMode, "Full")
+	}
+	if clusterMetadata.TotalNodes != 2 {
+		t.Fatalf("TotalNodes = %d, want %d", clusterMetadata.TotalNodes, 2)
+	}
+	if clusterMetadata.MasterNodesCount != 1 {
+		t.Fatalf("MasterNodesCount = %d, want %d", clusterMetadata.MasterNodesCount, 1)
+	}
+	if clusterMetadata.WorkerNodesCount != 1 {
+		t.Fatalf("WorkerNodesCount = %d, want %d", clusterMetadata.WorkerNodesCount, 1)
+	}
+}
+
 func newTestMetadata(t *testing.T, apiGroups []string, configMapData map[string]string) Metadata {
 	t.Helper()
 
@@ -234,6 +301,72 @@ func newTestMetadata(t *testing.T, apiGroups []string, configMapData map[string]
 	}
 }
 
+func newOpenShiftTestMetadata(t *testing.T) Metadata {
+	t.Helper()
+
+	clientSet := k8sfake.NewClientset(
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "master-0",
+				Labels: map[string]string{
+					"node-role.kubernetes.io/master":   "",
+					"node.kubernetes.io/instance-type": "m6i.2xlarge",
+				},
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "worker-0",
+				Labels: map[string]string{
+					"node-role.kubernetes.io/worker":   "",
+					"node.kubernetes.io/instance-type": "m6i.xlarge",
+				},
+			},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "kube-system",
+				Name:      "cluster-config-v1",
+			},
+			Data: map[string]string{
+				"install-config": `
+publish: External
+fips: true
+compute:
+- name: worker
+  architecture: amd64
+controlPlane:
+  architecture: amd64
+`,
+			},
+		},
+	)
+	discovery, ok := clientSet.Discovery().(*fake.FakeDiscovery)
+	if !ok {
+		t.Fatal("unexpected discovery type")
+	}
+	discovery.FakedServerVersion = &version.Info{GitVersion: "v1.31.6"}
+	for _, group := range []string{apiGroupOpenShiftConfig, apiGroupOpenShiftRoute} {
+		discovery.Resources = append(discovery.Resources, &metav1.APIResourceList{
+			GroupVersion: group + "/v1",
+		})
+	}
+
+	return Metadata{
+		connector: fakeConnector{
+			clientSet: clientSet,
+			dynamicClient: dynamicfake.NewSimpleDynamicClient(
+				runtime.NewScheme(),
+				newClusterVersion("4.18.9"),
+				newInfrastructure(),
+				newConfigNetwork(),
+				newOperatorNetwork(),
+			),
+			restConfig: &rest.Config{},
+		},
+	}
+}
+
 func newMicroShiftVersionConfigMap(data map[string]string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -241,5 +374,89 @@ func newMicroShiftVersionConfigMap(data map[string]string) *corev1.ConfigMap {
 			Name:      microShiftVersionConfigMap,
 		},
 		Data: data,
+	}
+}
+
+func newClusterVersion(version string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "config.openshift.io/v1",
+			"kind":       "ClusterVersion",
+			"metadata": map[string]interface{}{
+				"name": "version",
+			},
+			"status": map[string]interface{}{
+				"history": []interface{}{
+					map[string]interface{}{
+						"state":   completedUpdate,
+						"version": version,
+					},
+				},
+			},
+		},
+	}
+}
+
+func newInfrastructure() *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "config.openshift.io/v1",
+			"kind":       "Infrastructure",
+			"metadata": map[string]interface{}{
+				"name": "cluster",
+			},
+			"status": map[string]interface{}{
+				"infrastructureName": "ocp-test-abcde",
+				"platform":           "AWS",
+				"platformStatus": map[string]interface{}{
+					"aws": map[string]interface{}{
+						"region": "us-east-1",
+						"resourceTags": []interface{}{
+							map[string]interface{}{
+								"key":   "red-hat-clustertype",
+								"value": "rosa",
+							},
+						},
+					},
+					"type": "AWS",
+				},
+			},
+		},
+	}
+}
+
+func newConfigNetwork() *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "config.openshift.io/v1",
+			"kind":       "Network",
+			"metadata": map[string]interface{}{
+				"name": "cluster",
+			},
+			"status": map[string]interface{}{
+				"networkType": "OVNKubernetes",
+			},
+		},
+	}
+}
+
+func newOperatorNetwork() *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "operator.openshift.io/v1",
+			"kind":       "Network",
+			"metadata": map[string]interface{}{
+				"name": "cluster",
+			},
+			"spec": map[string]interface{}{
+				"defaultNetwork": map[string]interface{}{
+					"ovnKubernetesConfig": map[string]interface{}{
+						"ipsecConfig": map[string]interface{}{
+							"mode": "Full",
+						},
+					},
+				},
+			},
+		},
 	}
 }

--- a/ocp-metadata/ocp-metadata.go
+++ b/ocp-metadata/ocp-metadata.go
@@ -54,59 +54,86 @@ func NewMetadata(restConfig *rest.Config) (Metadata, error) {
 // GetClusterMetadata returns a clusterMetadata object from the given OCP cluster
 func (meta *Metadata) GetClusterMetadata() (ClusterMetadata, error) {
 	metadata := ClusterMetadata{}
+	distribution, microShiftVersion, err := meta.detectDistribution()
+	if err != nil {
+		return metadata, err
+	}
+	metadata.Distribution = distribution
+
+	metadata.K8SVersion, err = meta.getK8SVersion()
+	if err != nil {
+		return metadata, err
+	}
+	if err := meta.getNodesInfo(&metadata); err != nil {
+		return metadata, err
+	}
+
+	switch distribution {
+	case DistributionMicroShift:
+		metadata.MicroShift = true
+		metadata.MicroShiftVersion = microShiftVersion.version
+		metadata.MicroShiftMajorVersion = microShiftVersion.majorMinor
+	case DistributionOpenShift:
+		if err := meta.populateOpenShiftMetadata(&metadata); err != nil {
+			return metadata, err
+		}
+	}
+	return metadata, nil
+}
+
+func (meta *Metadata) populateOpenShiftMetadata(metadata *ClusterMetadata) error {
+	version, err := meta.getOCPVersionInfo()
+	if err != nil {
+		return err
+	}
+	metadata.OCPVersion, metadata.OCPMajorVersion = version.ocpVersion, version.ocpMajorVersion
+
 	infra, err := meta.getInfraDetails()
 	if err != nil {
-		return metadata, nil
+		return err
 	}
-	version, err := meta.getVersionInfo()
+	if infra == nil {
+		return nil
+	}
+	metadata.ClusterName, metadata.Platform, metadata.Region = infra.Status.InfrastructureName, infra.Status.Platform, infra.Status.PlatformStatus.Aws.Region
+	metadata.ClusterType = "self-managed"
+	for _, v := range infra.Status.PlatformStatus.Aws.ResourceTags {
+		if v.Key == "red-hat-clustertype" {
+			metadata.ClusterType = v.Value
+		}
+	}
+	metadata.SDNType, err = meta.getSDNInfo()
 	if err != nil {
-		return metadata, err
+		return err
 	}
-	metadata.OCPVersion, metadata.OCPMajorVersion, metadata.K8SVersion = version.ocpVersion, version.ocpMajorVersion, version.k8sVersion
-	if meta.getNodesInfo(&metadata) != nil {
-		return metadata, err
-	}
-	if infra != nil {
-		metadata.ClusterName, metadata.Platform, metadata.Region = infra.Status.InfrastructureName, infra.Status.Platform, infra.Status.PlatformStatus.Aws.Region
-		metadata.ClusterType = "self-managed"
-		for _, v := range infra.Status.PlatformStatus.Aws.ResourceTags {
-			if v.Key == "red-hat-clustertype" {
-				metadata.ClusterType = v.Value
-			}
-		}
-		metadata.SDNType, err = meta.getSDNInfo()
-		if err != nil {
-			return metadata, err
-		}
 
-		// Get InstallConfig to use in multiple methods
-		installConfig, err := meta.getClusterConfig()
-		if err != nil {
-			return metadata, err
-		}
-
-		metadata.Fips, err = meta.getFips(installConfig)
-		if err != nil {
-			return metadata, err
-		}
-		metadata.Publish, err = meta.getPublish(installConfig)
-		if err != nil {
-			return metadata, err
-		}
-		metadata.WorkerArch, err = meta.getComputeWorkerArch(installConfig)
-		if err != nil {
-			return metadata, err
-		}
-		metadata.ControlPlaneArch, err = meta.getControlPlaneArch(installConfig)
-		if err != nil {
-			return metadata, err
-		}
-		metadata.Ipsec, metadata.IpsecMode, err = meta.getIPSec()
-		if err != nil {
-			return metadata, err
-		}
+	// Get InstallConfig to use in multiple methods
+	installConfig, err := meta.getClusterConfig()
+	if err != nil {
+		return err
 	}
-	return metadata, err
+
+	metadata.Fips, err = meta.getFips(installConfig)
+	if err != nil {
+		return err
+	}
+	metadata.Publish, err = meta.getPublish(installConfig)
+	if err != nil {
+		return err
+	}
+	metadata.WorkerArch, err = meta.getComputeWorkerArch(installConfig)
+	if err != nil {
+		return err
+	}
+	metadata.ControlPlaneArch, err = meta.getControlPlaneArch(installConfig)
+	if err != nil {
+		return err
+	}
+	metadata.Ipsec, metadata.IpsecMode, err = meta.getIPSec()
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // GetPrometheus Returns Prometheus URL and a valid Bearer token
@@ -225,15 +252,18 @@ func (meta *Metadata) getInfraDetails() (*infraObj, error) {
 	return &infraJSON, err
 }
 
-// getVersionInfo obtains OCP and k8s version information
-func (meta *Metadata) getVersionInfo() (versionObj, error) {
-	var cv clusterVersion
-	var versionInfo versionObj
+func (meta *Metadata) getK8SVersion() (string, error) {
 	version, err := meta.connector.ClientSet().Discovery().ServerVersion()
 	if err != nil {
-		return versionInfo, err
+		return "", err
 	}
-	versionInfo.k8sVersion = version.GitVersion
+	return version.GitVersion, nil
+}
+
+// getOCPVersionInfo obtains OCP version information
+func (meta *Metadata) getOCPVersionInfo() (versionObj, error) {
+	var cv clusterVersion
+	var versionInfo versionObj
 	clusterVersion, err := meta.connector.DynamicClient().Resource(
 		schema.GroupVersionResource{
 			Group:    "config.openshift.io",

--- a/ocp-metadata/types.go
+++ b/ocp-metadata/types.go
@@ -75,7 +75,6 @@ type infraObj struct {
 type versionObj struct {
 	ocpVersion      string
 	ocpMajorVersion string
-	k8sVersion      string
 }
 
 // Type to store cluster info
@@ -90,27 +89,31 @@ type clusterVersion struct {
 
 // Type to store cluster metadata
 type ClusterMetadata struct {
-	MetricName       string `json:"metricName,omitempty"`
-	Platform         string `json:"platform,omitempty"`
-	ClusterType      string `json:"clusterType,omitempty"`
-	OCPVersion       string `json:"ocpVersion,omitempty"`
-	OCPMajorVersion  string `json:"ocpMajorVersion,omitempty"`
-	K8SVersion       string `json:"k8sVersion,omitempty"`
-	MasterNodesType  string `json:"masterNodesType,omitempty"`
-	WorkerNodesType  string `json:"workerNodesType,omitempty"`
-	MasterNodesCount int    `json:"masterNodesCount,omitempty"`
-	InfraNodesType   string `json:"infraNodesType,omitempty"`
-	WorkerNodesCount int    `json:"workerNodesCount,omitempty"`
-	InfraNodesCount  int    `json:"infraNodesCount,omitempty"`
-	OtherNodesCount  int    `json:"otherNodesCount,omitempty"`
-	TotalNodes       int    `json:"totalNodes,omitempty"`
-	SDNType          string `json:"sdnType,omitempty"`
-	ClusterName      string `json:"clusterName,omitempty"`
-	Region           string `json:"region,omitempty"`
-	Fips             bool   `json:"fips,omitempty"`
-	Publish          string `json:"publish,omitempty"`
-	WorkerArch       string `json:"workerArch,omitempty"`
-	ControlPlaneArch string `json:"controlPlaneArch,omitempty"`
-	Ipsec            bool   `json:"ipsec,omitempty"`
-	IpsecMode        string `json:"ipsecMode,omitempty"`
+	MetricName             string `json:"metricName,omitempty"`
+	Distribution           string `json:"distribution,omitempty"`
+	MicroShift             bool   `json:"microshift,omitempty"`
+	MicroShiftVersion      string `json:"microshiftVersion,omitempty"`
+	MicroShiftMajorVersion string `json:"microshiftMajorVersion,omitempty"`
+	Platform               string `json:"platform,omitempty"`
+	ClusterType            string `json:"clusterType,omitempty"`
+	OCPVersion             string `json:"ocpVersion,omitempty"`
+	OCPMajorVersion        string `json:"ocpMajorVersion,omitempty"`
+	K8SVersion             string `json:"k8sVersion,omitempty"`
+	MasterNodesType        string `json:"masterNodesType,omitempty"`
+	WorkerNodesType        string `json:"workerNodesType,omitempty"`
+	MasterNodesCount       int    `json:"masterNodesCount,omitempty"`
+	InfraNodesType         string `json:"infraNodesType,omitempty"`
+	WorkerNodesCount       int    `json:"workerNodesCount,omitempty"`
+	InfraNodesCount        int    `json:"infraNodesCount,omitempty"`
+	OtherNodesCount        int    `json:"otherNodesCount,omitempty"`
+	TotalNodes             int    `json:"totalNodes,omitempty"`
+	SDNType                string `json:"sdnType,omitempty"`
+	ClusterName            string `json:"clusterName,omitempty"`
+	Region                 string `json:"region,omitempty"`
+	Fips                   bool   `json:"fips,omitempty"`
+	Publish                string `json:"publish,omitempty"`
+	WorkerArch             string `json:"workerArch,omitempty"`
+	ControlPlaneArch       string `json:"controlPlaneArch,omitempty"`
+	Ipsec                  bool   `json:"ipsec,omitempty"`
+	IpsecMode              string `json:"ipsecMode,omitempty"`
 }


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds distribution-aware cluster metadata collection to `ocp-metadata`, including MicroShift support.

This change detects cluster distribution from live cluster state using API groups and the MicroShift `kube-public/microshift-version` ConfigMap. It adds the following metadata fields:

- `distribution`
- `microshift`
- `microshiftVersion`
- `microshiftMajorVersion`

OpenShift metadata collection remains scoped to OpenShift clusters. Kubernetes version and node counts continue to be populated for all distributions.

For existing OpenShift consumers, this is backwards-compatible: existing metadata fields keep their current JSON names and behavior. The MicroShift-specific fields use `omitempty`, so they are absent from non-MicroShift documents; the only always-populated schema addition is `distribution`.

## Related Tickets & Documents

- Related Issue # https://github.com/cloud-bulldozer/k8s-netperf/pull/251

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

## Testing

- System Under Test: local `go-commons` checkout on branch `microshift-metadata-support`, with unit tests using fake Kubernetes clients/discovery.
- Test steps:
  - Added table-driven tests for MicroShift ConfigMap detection, version parsing, API-group fallback detection, OpenShift detection, and vanilla Kubernetes detection.
  - Added a full `GetClusterMetadata()` wiring test for a MicroShift-shaped cluster.
  - Ran:

```bash
GOCACHE=/tmp/go-build GOMODCACHE=/tmp/gomod go test ./ocp-metadata
```

- Verification result:

```text
ok  	github.com/cloud-bulldozer/go-commons/v2/ocp-metadata	0.036s
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detect cluster distribution (Kubernetes / OpenShift / MicroShift) with fallback probing; capture MicroShift version and major.minor (parse errors no longer block detection).
  * Expose Distribution, MicroShift flag, MicroShiftVersion, MicroShiftMajorVersion and MetricName in collected metadata.

* **Refactor**
  * Metadata collection reorganized to branch by detected distribution; OpenShift-specific collection separated.

* **Tests**
  * Added unit tests covering distribution detection, MicroShift version parsing, and metadata extraction.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloud-bulldozer/go-commons/pull/65)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
