### PR TITLE
Add cluster capability metadata API

### DIFF
--- a/ocp-metadata/microshift.go
+++ b/ocp-metadata/microshift.go
@@ -27,9 +27,18 @@ import (
 const (
 	microShiftVersionNamespace = "kube-public"
 	microShiftVersionConfigMap = "microshift-version"
+)
 
-	apiGroupOpenShiftConfig = "config.openshift.io"
-	apiGroupOpenShiftRoute  = "route.openshift.io"
+// Well-known OpenShift API groups exposed for downstream capability checks.
+const (
+	// APIGroupOpenShiftConfig identifies the OpenShift config API group.
+	APIGroupOpenShiftConfig = "config.openshift.io"
+	// APIGroupOpenShiftRoute identifies the OpenShift route API group.
+	APIGroupOpenShiftRoute = "route.openshift.io"
+	// APIGroupOpenShiftBuild identifies the OpenShift build API group.
+	APIGroupOpenShiftBuild = "build.openshift.io"
+	// APIGroupOpenShiftSecurity identifies the OpenShift security API group.
+	APIGroupOpenShiftSecurity = "security.openshift.io"
 
 	// DistributionKubernetes identifies a vanilla Kubernetes cluster.
 	DistributionKubernetes = "kubernetes"
@@ -48,32 +57,57 @@ var microShiftMajorMinorRe = regexp.MustCompile(`^[0-9]+\.[0-9]+`)
 
 func (meta *Metadata) detectDistribution() (string, microShiftVersionInfo, error) {
 	cm, err := meta.readMicroShiftVersionConfigMap()
+	if distribution, info, detected := detectDistributionFromMicroShiftConfigMap(cm, err); detected {
+		return distribution, info, nil
+	}
+
+	apiGroups, err := meta.discoverAPIGroups()
+	if err != nil {
+		return DistributionKubernetes, microShiftVersionInfo{}, err
+	}
+
+	return detectDistributionFromAPIGroups(apiGroups), microShiftVersionInfo{}, nil
+}
+
+func detectDistributionFromMicroShiftConfigMap(cm *corev1.ConfigMap, err error) (string, microShiftVersionInfo, bool) {
 	switch {
 	case err == nil:
+		// ConfigMap presence is authoritative for MicroShift even if version
+		// fields are missing or malformed.
 		info, _ := parseMicroShiftVersion(cm)
-		return DistributionMicroShift, info, nil
+		return DistributionMicroShift, info, true
 	case apierrors.IsNotFound(err):
 		// Expected on OpenShift and vanilla Kubernetes.
 	default:
 		// Keep metadata collection best-effort when kube-public is unreadable.
 	}
+	return "", microShiftVersionInfo{}, false
+}
 
+func (meta *Metadata) discoverAPIGroups() (map[string]bool, error) {
 	groups, err := meta.connector.ClientSet().Discovery().ServerGroups()
 	if err != nil {
-		return DistributionKubernetes, microShiftVersionInfo{}, err
+		return nil, fmt.Errorf("discover API groups: %w", err)
 	}
-	apiGroups := make(map[string]bool, len(groups.Groups))
+	apiGroups := map[string]bool{}
+	if groups == nil {
+		// Defend against custom discovery clients returning nil with nil error.
+		return apiGroups, nil
+	}
 	for _, group := range groups.Groups {
 		apiGroups[group.Name] = true
 	}
+	return apiGroups, nil
+}
 
-	if apiGroups[apiGroupOpenShiftConfig] {
-		return DistributionOpenShift, microShiftVersionInfo{}, nil
+func detectDistributionFromAPIGroups(apiGroups map[string]bool) string {
+	if apiGroups[APIGroupOpenShiftConfig] {
+		return DistributionOpenShift
 	}
-	if apiGroups[apiGroupOpenShiftRoute] {
-		return DistributionMicroShift, microShiftVersionInfo{}, nil
+	if apiGroups[APIGroupOpenShiftRoute] {
+		return DistributionMicroShift
 	}
-	return DistributionKubernetes, microShiftVersionInfo{}, nil
+	return DistributionKubernetes
 }
 
 func (meta *Metadata) readMicroShiftVersionConfigMap() (*corev1.ConfigMap, error) {

--- a/ocp-metadata/microshift_test.go
+++ b/ocp-metadata/microshift_test.go
@@ -15,7 +15,9 @@
 package ocpmetadata
 
 import (
+	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -23,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/dynamic"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
@@ -63,7 +66,7 @@ func TestDetectDistribution(t *testing.T) {
 	}{
 		{
 			name:      "microshift configmap with version fields",
-			apiGroups: []string{apiGroupOpenShiftRoute},
+			apiGroups: []string{APIGroupOpenShiftRoute},
 			configMapData: map[string]string{
 				"version": "4.22.0~rc.2",
 				"major":   "4",
@@ -89,17 +92,17 @@ func TestDetectDistribution(t *testing.T) {
 		},
 		{
 			name:             "microshift route without config heuristic",
-			apiGroups:        []string{apiGroupOpenShiftRoute},
+			apiGroups:        []string{APIGroupOpenShiftRoute},
 			wantDistribution: DistributionMicroShift,
 		},
 		{
 			name:             "openshift",
-			apiGroups:        []string{apiGroupOpenShiftConfig, apiGroupOpenShiftRoute},
+			apiGroups:        []string{APIGroupOpenShiftConfig, APIGroupOpenShiftRoute},
 			wantDistribution: DistributionOpenShift,
 		},
 		{
 			name:             "microshift configmap wins over openshift api",
-			apiGroups:        []string{apiGroupOpenShiftConfig, apiGroupOpenShiftRoute},
+			apiGroups:        []string{APIGroupOpenShiftConfig, APIGroupOpenShiftRoute},
 			configMapData:    map[string]string{"version": "4.22.0~rc.2", "major": "4", "minor": "22"},
 			wantDistribution: DistributionMicroShift,
 			wantVersion:      "4.22.0~rc.2",
@@ -153,6 +156,353 @@ func TestDetectDistribution(t *testing.T) {
 	}
 }
 
+func TestClusterCapabilitiesHasAPIGroup(t *testing.T) {
+	var empty ClusterCapabilities
+	if empty.HasAPIGroup(APIGroupOpenShiftRoute) {
+		t.Fatal("zero-value ClusterCapabilities returned true, want false")
+	}
+
+	capabilities := ClusterCapabilities{APIGroups: map[string]bool{APIGroupOpenShiftRoute: true}}
+	if !capabilities.HasAPIGroup(APIGroupOpenShiftRoute) {
+		t.Fatalf("HasAPIGroup(%q) = false, want true", APIGroupOpenShiftRoute)
+	}
+	if capabilities.HasAPIGroup(APIGroupOpenShiftConfig) {
+		t.Fatalf("HasAPIGroup(%q) = true, want false", APIGroupOpenShiftConfig)
+	}
+}
+
+func TestClusterInfoHasAPIGroup(t *testing.T) {
+	var empty ClusterInfo
+	if empty.HasAPIGroup(APIGroupOpenShiftRoute) {
+		t.Fatal("zero-value ClusterInfo returned true, want false")
+	}
+
+	info := ClusterInfo{
+		Capabilities: ClusterCapabilities{
+			APIGroups: map[string]bool{APIGroupOpenShiftBuild: true},
+		},
+	}
+	if !info.HasAPIGroup(APIGroupOpenShiftBuild) {
+		t.Fatalf("HasAPIGroup(%q) = false, want true", APIGroupOpenShiftBuild)
+	}
+	if info.HasAPIGroup(APIGroupOpenShiftRoute) {
+		t.Fatalf("HasAPIGroup(%q) = true, want false", APIGroupOpenShiftRoute)
+	}
+}
+
+func TestAPIGroupConstants(t *testing.T) {
+	tests := map[string]string{
+		"APIGroupOpenShiftConfig":   APIGroupOpenShiftConfig,
+		"APIGroupOpenShiftRoute":    APIGroupOpenShiftRoute,
+		"APIGroupOpenShiftBuild":    APIGroupOpenShiftBuild,
+		"APIGroupOpenShiftSecurity": APIGroupOpenShiftSecurity,
+	}
+	want := map[string]string{
+		"APIGroupOpenShiftConfig":   "config.openshift.io",
+		"APIGroupOpenShiftRoute":    "route.openshift.io",
+		"APIGroupOpenShiftBuild":    "build.openshift.io",
+		"APIGroupOpenShiftSecurity": "security.openshift.io",
+	}
+	for name, got := range tests {
+		if got != want[name] {
+			t.Fatalf("%s = %q, want %q", name, got, want[name])
+		}
+	}
+}
+
+func TestDiscoverAPIGroups(t *testing.T) {
+	meta := newTestMetadata(t, []string{APIGroupOpenShiftRoute, APIGroupOpenShiftSecurity}, nil)
+
+	apiGroups, err := meta.discoverAPIGroups()
+	if err != nil {
+		t.Fatalf("discoverAPIGroups returned unexpected error: %v", err)
+	}
+	for _, group := range []string{APIGroupOpenShiftRoute, APIGroupOpenShiftSecurity} {
+		if !apiGroups[group] {
+			t.Fatalf("apiGroups[%q] = false, want true", group)
+		}
+	}
+	if apiGroups[APIGroupOpenShiftConfig] {
+		t.Fatalf("apiGroups[%q] = true, want false", APIGroupOpenShiftConfig)
+	}
+}
+
+func TestDiscoverAPIGroupsError(t *testing.T) {
+	meta := newTestMetadata(t, nil, nil)
+	injectDiscoveryError(t, meta)
+
+	_, err := meta.discoverAPIGroups()
+	if err == nil {
+		t.Fatal("discoverAPIGroups returned nil error, want error")
+	}
+	if !strings.Contains(err.Error(), "discover API groups") {
+		t.Fatalf("discoverAPIGroups error = %q, want discovery context", err.Error())
+	}
+}
+
+type wrappedClientset struct {
+	kubernetes.Interface
+	discovery discovery.DiscoveryInterface
+}
+
+func (w wrappedClientset) Discovery() discovery.DiscoveryInterface {
+	return w.discovery
+}
+
+type nilGroupsDiscovery struct {
+	discovery.DiscoveryInterface
+}
+
+func (nilGroupsDiscovery) ServerGroups() (*metav1.APIGroupList, error) {
+	return nil, nil
+}
+
+func TestDiscoverAPIGroupsNilGroups(t *testing.T) {
+	meta := newTestMetadata(t, nil, nil)
+	clientSet := meta.connector.ClientSet()
+	meta.connector = fakeConnector{
+		clientSet: wrappedClientset{
+			Interface: clientSet,
+			discovery: nilGroupsDiscovery{
+				DiscoveryInterface: clientSet.Discovery(),
+			},
+		},
+		dynamicClient: meta.connector.DynamicClient(),
+		restConfig:    meta.connector.RestConfig(),
+	}
+
+	apiGroups, err := meta.discoverAPIGroups()
+	if err != nil {
+		t.Fatalf("discoverAPIGroups returned unexpected error: %v", err)
+	}
+	if apiGroups == nil {
+		t.Fatal("discoverAPIGroups returned nil map, want empty map")
+	}
+	if len(apiGroups) != 0 {
+		t.Fatalf("apiGroups = %#v, want empty map", apiGroups)
+	}
+}
+
+func TestGetClusterInfo(t *testing.T) {
+	tests := []struct {
+		name                  string
+		meta                  func(*testing.T) Metadata
+		wantDistribution      string
+		wantMicroShift        bool
+		wantMicroShiftVersion string
+		wantMajorVersion      string
+		wantK8SVersion        string
+		wantTotalNodes        int
+		wantOCPVersion        string
+		wantAPIGroup          []string
+		wantNoAPIGroup        []string
+	}{
+		{
+			name: "kubernetes",
+			meta: func(t *testing.T) Metadata {
+				return newTestMetadata(t, []string{"apps"}, nil)
+			},
+			wantDistribution: DistributionKubernetes,
+			wantK8SVersion:   "v1.35.3",
+			wantTotalNodes:   1,
+			wantAPIGroup:     []string{"apps"},
+			wantNoAPIGroup:   []string{APIGroupOpenShiftConfig, APIGroupOpenShiftRoute},
+		},
+		{
+			name:             "openshift",
+			meta:             newOpenShiftTestMetadata,
+			wantDistribution: DistributionOpenShift,
+			wantK8SVersion:   "v1.31.6",
+			wantTotalNodes:   2,
+			wantOCPVersion:   "4.18.9",
+			wantAPIGroup:     []string{APIGroupOpenShiftConfig, APIGroupOpenShiftRoute},
+		},
+		{
+			name: "microshift via configmap",
+			meta: func(t *testing.T) Metadata {
+				return newTestMetadata(t, []string{APIGroupOpenShiftRoute, APIGroupOpenShiftSecurity}, map[string]string{
+					"version": "4.22.0~rc.2",
+					"major":   "4",
+					"minor":   "22",
+				})
+			},
+			wantDistribution:      DistributionMicroShift,
+			wantMicroShift:        true,
+			wantMicroShiftVersion: "4.22.0~rc.2",
+			wantMajorVersion:      "4.22",
+			wantK8SVersion:        "v1.35.3",
+			wantTotalNodes:        1,
+			wantAPIGroup:          []string{APIGroupOpenShiftRoute, APIGroupOpenShiftSecurity},
+			wantNoAPIGroup:        []string{APIGroupOpenShiftConfig},
+		},
+		{
+			name: "microshift via route/config heuristic",
+			meta: func(t *testing.T) Metadata {
+				return newTestMetadata(t, []string{APIGroupOpenShiftRoute}, nil)
+			},
+			wantDistribution: DistributionMicroShift,
+			wantMicroShift:   true,
+			wantK8SVersion:   "v1.35.3",
+			wantTotalNodes:   1,
+			wantAPIGroup:     []string{APIGroupOpenShiftRoute},
+			wantNoAPIGroup:   []string{APIGroupOpenShiftConfig},
+		},
+		{
+			name: "microshift configmap wins over openshift api groups",
+			meta: func(t *testing.T) Metadata {
+				return newTestMetadata(t, []string{APIGroupOpenShiftConfig, APIGroupOpenShiftRoute}, map[string]string{
+					"version": "4.22.0~rc.2",
+					"major":   "4",
+					"minor":   "22",
+				})
+			},
+			wantDistribution:      DistributionMicroShift,
+			wantMicroShift:        true,
+			wantMicroShiftVersion: "4.22.0~rc.2",
+			wantMajorVersion:      "4.22",
+			wantK8SVersion:        "v1.35.3",
+			wantTotalNodes:        1,
+			wantAPIGroup:          []string{APIGroupOpenShiftConfig, APIGroupOpenShiftRoute},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			meta := tt.meta(t)
+			info, err := meta.GetClusterInfo()
+			if err != nil {
+				t.Fatalf("GetClusterInfo returned unexpected error: %v", err)
+			}
+			if info.Metadata.Distribution != tt.wantDistribution {
+				t.Fatalf("Distribution = %q, want %q", info.Metadata.Distribution, tt.wantDistribution)
+			}
+			if info.Metadata.MicroShift != tt.wantMicroShift {
+				t.Fatalf("MicroShift = %v, want %v", info.Metadata.MicroShift, tt.wantMicroShift)
+			}
+			if info.Metadata.MicroShiftVersion != tt.wantMicroShiftVersion {
+				t.Fatalf("MicroShiftVersion = %q, want %q", info.Metadata.MicroShiftVersion, tt.wantMicroShiftVersion)
+			}
+			if info.Metadata.MicroShiftMajorVersion != tt.wantMajorVersion {
+				t.Fatalf("MicroShiftMajorVersion = %q, want %q", info.Metadata.MicroShiftMajorVersion, tt.wantMajorVersion)
+			}
+			if info.Metadata.K8SVersion != tt.wantK8SVersion {
+				t.Fatalf("K8SVersion = %q, want %q", info.Metadata.K8SVersion, tt.wantK8SVersion)
+			}
+			if info.Metadata.TotalNodes != tt.wantTotalNodes {
+				t.Fatalf("TotalNodes = %d, want %d", info.Metadata.TotalNodes, tt.wantTotalNodes)
+			}
+			if info.Metadata.OCPVersion != tt.wantOCPVersion {
+				t.Fatalf("OCPVersion = %q, want %q", info.Metadata.OCPVersion, tt.wantOCPVersion)
+			}
+			for _, group := range tt.wantAPIGroup {
+				if !info.Capabilities.HasAPIGroup(group) {
+					t.Fatalf("HasAPIGroup(%q) = false, want true", group)
+				}
+			}
+			for _, group := range tt.wantNoAPIGroup {
+				if info.Capabilities.HasAPIGroup(group) {
+					t.Fatalf("HasAPIGroup(%q) = true, want false", group)
+				}
+			}
+		})
+	}
+}
+
+func TestGetClusterInfoDiscoveryError(t *testing.T) {
+	meta := newTestMetadata(t, nil, nil)
+	injectDiscoveryError(t, meta)
+
+	info, err := meta.GetClusterInfo()
+	if err == nil {
+		t.Fatal("GetClusterInfo returned nil error, want error")
+	}
+	if !strings.Contains(err.Error(), "discover API groups") {
+		t.Fatalf("GetClusterInfo error = %q, want discovery context", err.Error())
+	}
+	if info.Metadata != (ClusterMetadata{}) {
+		t.Fatalf("Metadata = %+v, want zero value", info.Metadata)
+	}
+	if info.Capabilities.APIGroups != nil {
+		t.Fatalf("APIGroups = %#v, want nil", info.Capabilities.APIGroups)
+	}
+}
+
+func TestGetClusterInfoReturnsPartialInfoOnMetadataError(t *testing.T) {
+	meta := newOpenShiftMetadataWithMissingNetwork(t)
+
+	info, err := meta.GetClusterInfo()
+	if err == nil {
+		t.Fatal("GetClusterInfo returned nil error, want metadata enrichment error")
+	}
+	if !info.Capabilities.HasAPIGroup(APIGroupOpenShiftConfig) {
+		t.Fatalf("HasAPIGroup(%q) = false, want true", APIGroupOpenShiftConfig)
+	}
+	if !info.Capabilities.HasAPIGroup(APIGroupOpenShiftRoute) {
+		t.Fatalf("HasAPIGroup(%q) = false, want true", APIGroupOpenShiftRoute)
+	}
+	if info.Metadata.Distribution != DistributionOpenShift {
+		t.Fatalf("Distribution = %q, want %q", info.Metadata.Distribution, DistributionOpenShift)
+	}
+	if info.Metadata.K8SVersion != "v1.31.6" {
+		t.Fatalf("K8SVersion = %q, want %q", info.Metadata.K8SVersion, "v1.31.6")
+	}
+	if info.Metadata.TotalNodes != 1 {
+		t.Fatalf("TotalNodes = %d, want %d", info.Metadata.TotalNodes, 1)
+	}
+	if info.Metadata.OCPVersion != "4.18.9" {
+		t.Fatalf("OCPVersion = %q, want %q", info.Metadata.OCPVersion, "4.18.9")
+	}
+	if info.Metadata.ClusterName != "ocp-test-abcde" {
+		t.Fatalf("ClusterName = %q, want %q", info.Metadata.ClusterName, "ocp-test-abcde")
+	}
+}
+
+func TestClusterInfoJSONOmitsCapabilities(t *testing.T) {
+	info := ClusterInfo{
+		Metadata: ClusterMetadata{
+			Distribution: DistributionMicroShift,
+			MicroShift:   true,
+			TotalNodes:   1,
+		},
+		Capabilities: ClusterCapabilities{
+			APIGroups: map[string]bool{APIGroupOpenShiftRoute: true},
+		},
+	}
+
+	metadataPayload, err := json.Marshal(info.Metadata)
+	if err != nil {
+		t.Fatalf("Marshal ClusterMetadata returned unexpected error: %v", err)
+	}
+	assertNoCapabilityJSON(t, metadataPayload)
+
+	capabilitiesPayload, err := json.Marshal(info.Capabilities)
+	if err != nil {
+		t.Fatalf("Marshal ClusterCapabilities returned unexpected error: %v", err)
+	}
+	if string(capabilitiesPayload) != "{}" {
+		t.Fatalf("ClusterCapabilities JSON = %s, want {}", capabilitiesPayload)
+	}
+
+	infoPayload, err := json.Marshal(info)
+	if err != nil {
+		t.Fatalf("Marshal ClusterInfo returned unexpected error: %v", err)
+	}
+	assertNoCapabilityJSON(t, infoPayload)
+	if strings.Contains(string(infoPayload), "Capabilities") || strings.Contains(string(infoPayload), "capabilities") {
+		t.Fatalf("ClusterInfo JSON contains capabilities: %s", infoPayload)
+	}
+}
+
+func assertNoCapabilityJSON(t *testing.T, payload []byte) {
+	t.Helper()
+
+	for _, value := range []string{"APIGroups", "apiGroups", APIGroupOpenShiftRoute} {
+		if strings.Contains(string(payload), value) {
+			t.Fatalf("JSON payload contains %q: %s", value, payload)
+		}
+	}
+}
+
 func injectDiscoveryError(t *testing.T, meta Metadata) {
 	t.Helper()
 
@@ -166,7 +516,7 @@ func injectDiscoveryError(t *testing.T, meta Metadata) {
 }
 
 func TestGetClusterMetadataMicroShift(t *testing.T) {
-	meta := newTestMetadata(t, []string{apiGroupOpenShiftRoute}, map[string]string{
+	meta := newTestMetadata(t, []string{APIGroupOpenShiftRoute}, map[string]string{
 		"version": "4.22.0~rc.2",
 		"major":   "4",
 		"minor":   "22",
@@ -195,6 +545,22 @@ func TestGetClusterMetadataMicroShift(t *testing.T) {
 		t.Fatalf("TotalNodes = %d, want %d", clusterMetadata.TotalNodes, 1)
 	}
 	assertEmptyOpenShiftMetadata(t, clusterMetadata)
+}
+
+func TestGetClusterMetadataDiscoveryError(t *testing.T) {
+	meta := newTestMetadata(t, nil, nil)
+	injectDiscoveryError(t, meta)
+
+	clusterMetadata, err := meta.GetClusterMetadata()
+	if err == nil {
+		t.Fatal("GetClusterMetadata returned nil error, want error")
+	}
+	if !strings.Contains(err.Error(), "discover API groups") {
+		t.Fatalf("GetClusterMetadata error = %q, want discovery context", err.Error())
+	}
+	if clusterMetadata != (ClusterMetadata{}) {
+		t.Fatalf("ClusterMetadata = %+v, want zero value", clusterMetadata)
+	}
 }
 
 func TestGetClusterMetadataOpenShift(t *testing.T) {
@@ -403,7 +769,7 @@ controlPlane:
 		t.Fatal("unexpected discovery type")
 	}
 	discovery.FakedServerVersion = &version.Info{GitVersion: "v1.31.6"}
-	for _, group := range []string{apiGroupOpenShiftConfig, apiGroupOpenShiftRoute} {
+	for _, group := range []string{APIGroupOpenShiftConfig, APIGroupOpenShiftRoute} {
 		discovery.Resources = append(discovery.Resources, &metav1.APIResourceList{
 			GroupVersion: group + "/v1",
 		})
@@ -418,6 +784,44 @@ controlPlane:
 				newInfrastructure(),
 				newConfigNetwork(),
 				newOperatorNetwork(),
+			),
+			restConfig: &rest.Config{},
+		},
+	}
+}
+
+func newOpenShiftMetadataWithMissingNetwork(t *testing.T) Metadata {
+	t.Helper()
+
+	clientSet := k8sfake.NewClientset(
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "master-0",
+				Labels: map[string]string{
+					"node-role.kubernetes.io/master":   "",
+					"node.kubernetes.io/instance-type": "m6i.2xlarge",
+				},
+			},
+		},
+	)
+	discovery, ok := clientSet.Discovery().(*fake.FakeDiscovery)
+	if !ok {
+		t.Fatal("unexpected discovery type")
+	}
+	discovery.FakedServerVersion = &version.Info{GitVersion: "v1.31.6"}
+	for _, group := range []string{APIGroupOpenShiftConfig, APIGroupOpenShiftRoute} {
+		discovery.Resources = append(discovery.Resources, &metav1.APIResourceList{
+			GroupVersion: group + "/v1",
+		})
+	}
+
+	return Metadata{
+		connector: fakeConnector{
+			clientSet: clientSet,
+			dynamicClient: dynamicfake.NewSimpleDynamicClient(
+				runtime.NewScheme(),
+				newClusterVersion("4.18.9"),
+				newInfrastructure(),
 			),
 			restConfig: &rest.Config{},
 		},

--- a/ocp-metadata/ocp-metadata.go
+++ b/ocp-metadata/ocp-metadata.go
@@ -53,17 +53,52 @@ func NewMetadata(restConfig *rest.Config) (Metadata, error) {
 
 // GetClusterMetadata returns a clusterMetadata object from the given OCP cluster
 func (meta *Metadata) GetClusterMetadata() (ClusterMetadata, error) {
-	metadata := ClusterMetadata{}
 	distribution, microShiftVersion, err := meta.detectDistribution()
 	if err != nil {
-		return metadata, err
+		return ClusterMetadata{}, err
 	}
+	return meta.getClusterMetadata(distribution, microShiftVersion)
+}
+
+// GetClusterInfo returns cluster metadata and runtime capabilities.
+// It always discovers API groups so Capabilities reflects the cluster even when
+// the MicroShift ConfigMap is present and authoritative for distribution.
+// If later metadata enrichment fails, the returned ClusterInfo contains the
+// capabilities and any metadata collected before the failure.
+func (meta *Metadata) GetClusterInfo() (ClusterInfo, error) {
+	cm, cmErr := meta.readMicroShiftVersionConfigMap()
+
+	apiGroups, err := meta.discoverAPIGroups()
+	if err != nil {
+		return ClusterInfo{}, err
+	}
+
+	distribution := detectDistributionFromAPIGroups(apiGroups)
+	microShiftVersion := microShiftVersionInfo{}
+	if cmDistribution, info, detected := detectDistributionFromMicroShiftConfigMap(cm, cmErr); detected {
+		distribution = cmDistribution
+		microShiftVersion = info
+	}
+
+	metadata, err := meta.getClusterMetadata(distribution, microShiftVersion)
+	info := ClusterInfo{
+		Metadata: metadata,
+		Capabilities: ClusterCapabilities{
+			APIGroups: apiGroups,
+		},
+	}
+	return info, err
+}
+
+func (meta *Metadata) getClusterMetadata(distribution string, microShiftVersion microShiftVersionInfo) (ClusterMetadata, error) {
+	metadata := ClusterMetadata{}
 	metadata.Distribution = distribution
 
-	metadata.K8SVersion, err = meta.getK8SVersion()
+	k8sVersion, err := meta.getK8SVersion()
 	if err != nil {
 		return metadata, err
 	}
+	metadata.K8SVersion = k8sVersion
 	if err := meta.getNodesInfo(&metadata); err != nil {
 		return metadata, err
 	}

--- a/ocp-metadata/types.go
+++ b/ocp-metadata/types.go
@@ -87,6 +87,29 @@ type clusterVersion struct {
 	} `json:"status"`
 }
 
+// ClusterCapabilities stores runtime cluster capabilities used for branching.
+type ClusterCapabilities struct {
+	APIGroups map[string]bool `json:"-"`
+}
+
+// HasAPIGroup returns whether the cluster advertises the given API group.
+func (c ClusterCapabilities) HasAPIGroup(group string) bool {
+	return c.APIGroups[group]
+}
+
+// ClusterInfo contains cluster metadata and runtime capabilities.
+// It is intended for in-process use: JSON output keeps metadata under the
+// metadata key and omits runtime capabilities.
+type ClusterInfo struct {
+	Metadata     ClusterMetadata     `json:"metadata"`
+	Capabilities ClusterCapabilities `json:"-"`
+}
+
+// HasAPIGroup returns whether the cluster advertises the given API group.
+func (i ClusterInfo) HasAPIGroup(group string) bool {
+	return i.Capabilities.HasAPIGroup(group)
+}
+
 // Type to store cluster metadata
 type ClusterMetadata struct {
 	MetricName             string `json:"metricName,omitempty"`


### PR DESCRIPTION
Expose GetClusterInfo() alongside GetClusterMetadata() so callers can
branch on runtime cluster capabilities (advertised API groups) without
duplicating discovery logic. Capabilities are kept separate from
ClusterMetadata and omitted from JSON output, since they describe
runtime state rather than data to index.

The new public surface is ClusterInfo, ClusterCapabilities,
GetClusterInfo(), HasAPIGroup() on both types, and well-known
APIGroupOpenShift{Config,Route,Build,Security} constants.

Refactor distribution detection so ConfigMap-based detection and API
group discovery are reusable helpers, letting GetClusterInfo build
metadata and capabilities from a single ServerGroups snapshot.
GetClusterMetadata behavior is unchanged; GetClusterInfo returns
discovered capabilities plus partial metadata when later enrichment
fails, so callers can still inspect what was collected.

Add unit tests covering all three distributions, nil-safe HasAPIGroup,
JSON omission, exported constant values, discovery errors, and
partial-info error returns.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds an additive ocp-metadata capability API for advertised API groups.
The API keeps runtime capabilities separate from ClusterMetadata so
existing metadata indexing shape stays unchanged.

## Related Tickets & Documents

N/A

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

## Testing

System Under Test: go-commons ocp-metadata package using fake Kubernetes
clients for Kubernetes, OpenShift, and MicroShift detection paths.

Steps performed:

1. Ran go test ./ocp-metadata/...
2. Ran go test ./...

Verification:

Both test commands passed. The test suite covers Kubernetes, OpenShift,
MicroShift via ConfigMap, MicroShift via route/config heuristic,
nil-safe HasAPIGroup, JSON omission, exported constants, discovery
errors, and partial-info error returns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved cluster distribution detection with richer API-group awareness and a clearer precedence between config-based and API-based signals.
  * Runtime cluster capabilities exposed so callers can query available API groups.

* **Bug Fixes**
  * More reliable MicroShift/OpenShift/Kubernetes differentiation with defensive handling of missing discovery data and better precedence rules.

* **Tests**
  * Expanded unit tests covering detection paths, API-group discovery, error handling, partial enrichment, and JSON marshaling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloud-bulldozer/go-commons/pull/66)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->