### PR TITLE
Hcp platforms

### DIFF
--- a/cmd/ocp-metadata/main.go
+++ b/cmd/ocp-metadata/main.go
@@ -91,13 +91,12 @@ func getRestConfig() (*rest.Config, error) {
 		}
 	}
 
-	// Try in-cluster config first
-	if config, err := rest.InClusterConfig(); err == nil {
-		return config, nil
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	// Fall back to in-cluster config
+	if err != nil {
+		config, err = rest.InClusterConfig()
 	}
-
-	// Fall back to kubeconfig file
-	return clientcmd.BuildConfigFromFlags("", kubeconfig)
+	return config, err
 }
 
 // outputData formats and prints data based on the output format

--- a/cmd/ocp-metadata/main.go
+++ b/cmd/ocp-metadata/main.go
@@ -101,8 +101,7 @@ func getRestConfig() (*rest.Config, error) {
 }
 
 // outputData formats and prints data based on the output format
-func outputData(data interface{}) error {
+func outputData(data any) error {
 	encoder := json.NewEncoder(os.Stdout)
-	encoder.SetIndent("", "  ")
 	return encoder.Encode(data)
 }

--- a/ocp-metadata/ocp-metadata.go
+++ b/ocp-metadata/ocp-metadata.go
@@ -135,6 +135,17 @@ func (meta *Metadata) populateOpenShiftMetadata(metadata *ClusterMetadata) error
 	for _, v := range infra.Status.PlatformStatus.Aws.ResourceTags {
 		if v.Key == "red-hat-clustertype" {
 			metadata.ClusterType = v.Value
+			if metadata.ClusterType == "rosa" && infra.Status.ControlPlaneTopology == "External" {
+				metadata.ClusterType = "rosa-hcp"
+			}
+		}
+	}
+	for _, v := range infra.Status.PlatformStatus.Azure.ResourceTags {
+		if v.Key == "red-hat-clustertype" {
+			metadata.ClusterType = v.Value
+			if metadata.ClusterType == "aro" && infra.Status.ControlPlaneTopology == "External" {
+				metadata.ClusterType = "aro-hcp"
+			}
 		}
 	}
 	metadata.SDNType, err = meta.getSDNInfo()

--- a/ocp-metadata/ocp-metadata.go
+++ b/ocp-metadata/ocp-metadata.go
@@ -116,6 +116,17 @@ func (meta *Metadata) getClusterMetadata(distribution string, microShiftVersion 
 	return metadata, nil
 }
 
+func regionFromInfra(infra *infraObj) string {
+	switch infra.Status.Platform {
+	case "AWS":
+		return infra.Status.PlatformStatus.Aws.Region
+	case "Azure":
+		return infra.Status.PlatformStatus.Azure.Region
+	default:
+		return ""
+	}
+}
+
 func (meta *Metadata) populateOpenShiftMetadata(metadata *ClusterMetadata) error {
 	version, err := meta.getOCPVersionInfo()
 	if err != nil {
@@ -130,7 +141,9 @@ func (meta *Metadata) populateOpenShiftMetadata(metadata *ClusterMetadata) error
 	if infra == nil {
 		return nil
 	}
-	metadata.ClusterName, metadata.Platform, metadata.Region = infra.Status.InfrastructureName, infra.Status.Platform, infra.Status.PlatformStatus.Aws.Region
+	metadata.ClusterName = infra.Status.InfrastructureName
+	metadata.Platform = infra.Status.Platform
+	metadata.Region = regionFromInfra(infra)
 	metadata.ClusterType = "self-managed"
 	for _, v := range infra.Status.PlatformStatus.Aws.ResourceTags {
 		if v.Key == "red-hat-clustertype" {

--- a/ocp-metadata/types.go
+++ b/ocp-metadata/types.go
@@ -121,7 +121,7 @@ func (i ClusterInfo) HasAPIGroup(group string) bool {
 type ClusterMetadata struct {
 	MetricName             string `json:"metricName,omitempty"`
 	Distribution           string `json:"distribution,omitempty"`
-	MicroShift             bool   `json:"microshift,omitempty"`
+	MicroShift             bool   `json:"microshift"`
 	MicroShiftVersion      string `json:"microshiftVersion,omitempty"`
 	MicroShiftMajorVersion string `json:"microshiftMajorVersion,omitempty"`
 	Platform               string `json:"platform,omitempty"`
@@ -140,10 +140,10 @@ type ClusterMetadata struct {
 	SDNType                string `json:"sdnType,omitempty"`
 	ClusterName            string `json:"clusterName,omitempty"`
 	Region                 string `json:"region,omitempty"`
-	Fips                   bool   `json:"fips,omitempty"`
+	Fips                   bool   `json:"fips"`
 	Publish                string `json:"publish,omitempty"`
 	WorkerArch             string `json:"workerArch,omitempty"`
 	ControlPlaneArch       string `json:"controlPlaneArch,omitempty"`
-	Ipsec                  bool   `json:"ipsec,omitempty"`
+	Ipsec                  bool   `json:"ipsec"`
 	IpsecMode              string `json:"ipsecMode,omitempty"`
 }

--- a/ocp-metadata/types.go
+++ b/ocp-metadata/types.go
@@ -55,10 +55,11 @@ var vmiGVR = schema.GroupVersionResource{
 // Using well known node labels like topology.kubernetes.io/region to get the cloud region
 type infraObj struct {
 	Status struct {
-		InfrastructureName string `json:"infrastructureName"`
-		Platform           string `json:"platform"`
-		Type               string `json:"type"`
-		PlatformStatus     struct {
+		InfrastructureName   string `json:"infrastructureName"`
+		Platform             string `json:"platform"`
+		Type                 string `json:"type"`
+		ControlPlaneTopology string `json:"controlPlaneTopology"`
+		PlatformStatus       struct {
 			Aws struct {
 				Region       string `json:"region"`
 				ResourceTags []struct {
@@ -66,7 +67,13 @@ type infraObj struct {
 					Value string `json:"value"`
 				} `json:"resourceTags"`
 			} `json:"aws"`
-			Type string `json:"type"`
+			Azure struct {
+				Region       string `json:"region"`
+				ResourceTags []struct {
+					Key   string `json:"key"`
+					Value string `json:"value"`
+				} `json:"resourceTags"`
+			} `json:"azure"`
 		} `json:"platformStatus"`
 	} `json:"status"`
 }


### PR DESCRIPTION
## Type of change

- [x] Optimization
## Description

Append hcp to External control-plane topologies to be aligned with e2e-benchmarking metadata generation:

```shell
rsevilla@toolbx ~/labs/go-commons (hcp-platforms) $ go build -o bin/ocp-metadata ./cmd/ocp-metadata
rsevilla@toolbx ~/labs/go-commons (hcp-platforms) $ bin/ocp-metadata
{"distribution":"openshift","platform":"AWS","clusterType":"rosa-hcp","ocpVersion":"4.22.0-0.nightly-2026-06-01-013201","ocpMajorVersion":"4.22","k8sVersion":"v1.35.5","workerNodesType":"c5a.xlarge","infraNodesType":"r5.4xlarge","workerNodesCount":2,"infraNodesCount":3,"totalNodes":5,"sdnType":"OVNKubernetes","clusterName":"2qq2eoo5mogisqjr6v58sclpn1pebhal","region":"us-east-2","ipsecMode":"Disabled"}
```

Also remove JSON indentation, this is required to be used as --input-vars in orion:

Context: https://github.com/openshift/release/pull/80284


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved detection and remapping of ROSA/ARO cluster types based on control plane topology.
  * Region determination enhanced from platform infrastructure data.

* **Changes**
  * JSON output is now compact (no pretty-printing).
  * Kubeconfig resolution order adjusted for credential selection.
  * Boolean metadata fields (microshift, fips, ipsec) are always included in output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->