### PR TITLE
Release workflow for ocp-metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux, darwin]
+        goarch: [amd64, arm64]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+
+      - name: Build
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: go build -o ocp-metadata-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/ocp-metadata
+
+      - name: Upload Release Asset
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ocp-metadata-${{ matrix.goos }}-${{ matrix.goarch }}


### PR DESCRIPTION
## Type of change

- [x] New feature

## Description

Release workflow for ocp-metadata binary. Tested at https://github.com/rsevilla87/go-commons/releases