### PR TITLE
Add tokenFile support for Prometheus token refresh

### DIFF
--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -19,6 +19,8 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"os"
+	"strings"
 	"time"
 
 	api "github.com/prometheus/client_golang/api"
@@ -36,11 +38,32 @@ func (bat authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", bat.token))
 	}
 
+	if bat.tokenFile != "" {
+		tokenBytes, err := os.ReadFile(bat.tokenFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read token file %s: %w", bat.tokenFile, err)
+		}
+		token := strings.TrimSpace(string(tokenBytes))
+		if token != "" {
+			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+		}
+	}
+
 	return bat.Transport.RoundTrip(req)
 }
 
 // NewClient creates a prometheus struct instance with the given parameters
 func NewClient(url, token, username, password string, tlsSkipVerify bool) (*Prometheus, error) {
+	return newClient(url, token, "", username, password, tlsSkipVerify)
+}
+
+// NewClientWithTokenFile creates a prometheus client that re-reads the bearer
+// token from the given file on every request, allowing external token rotation.
+func NewClientWithTokenFile(url, tokenFile, username, password string, tlsSkipVerify bool) (*Prometheus, error) {
+	return newClient(url, "", tokenFile, username, password, tlsSkipVerify)
+}
+
+func newClient(url, token, tokenFile, username, password string, tlsSkipVerify bool) (*Prometheus, error) {
 	prometheus := Prometheus{
 		Endpoint: url,
 	}
@@ -49,6 +72,7 @@ func NewClient(url, token, username, password string, tlsSkipVerify bool) (*Prom
 		RoundTripper: authTransport{
 			Transport: &http.Transport{Proxy: http.ProxyFromEnvironment, TLSClientConfig: &tls.Config{InsecureSkipVerify: tlsSkipVerify}},
 			token:     token,
+			tokenFile: tokenFile,
 			username:  username,
 			password:  password,
 		},

--- a/prometheus/prometheus_test.go
+++ b/prometheus/prometheus_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -83,6 +84,80 @@ var _ = Describe("Tests for Prometheus", func() {
 			//Asserting no of times mocks are called
 			Expect(count).To(BeEquivalentTo(0))
 			Expect(err).To(BeNil())
+		})
+	})
+
+	Context("Tests for RoundTrip() with tokenFile", func() {
+		var tmpDir string
+		var tokenFilePath string
+		var noopTransport http.RoundTripper
+
+		BeforeEach(func() {
+			var err error
+			tmpDir, err = os.MkdirTemp("", "token-test-*")
+			Expect(err).NotTo(HaveOccurred())
+			tokenFilePath = tmpDir + "/token"
+			noopTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				return &http.Response{StatusCode: 200}, nil
+			})
+		})
+
+		AfterEach(func() {
+			Expect(os.RemoveAll(tmpDir)).To(Succeed())
+		})
+
+		It("reads token from file on each request", func() {
+			Expect(os.WriteFile(tokenFilePath, []byte("token-v1"), 0600)).To(Succeed())
+			bat := authTransport{tokenFile: tokenFilePath, Transport: noopTransport}
+
+			req, _ := http.NewRequest(http.MethodGet, "https://example.com/api", nil)
+			_, err := bat.RoundTrip(req)
+			Expect(err).To(BeNil())
+			Expect(req.Header.Get("Authorization")).To(Equal("Bearer token-v1"))
+
+			Expect(os.WriteFile(tokenFilePath, []byte("token-v2"), 0600)).To(Succeed())
+			req2, _ := http.NewRequest(http.MethodGet, "https://example.com/api", nil)
+			_, err = bat.RoundTrip(req2)
+			Expect(err).To(BeNil())
+			Expect(req2.Header.Get("Authorization")).To(Equal("Bearer token-v2"))
+		})
+
+		It("trims whitespace from token file contents", func() {
+			Expect(os.WriteFile(tokenFilePath, []byte("  my-token \n\n"), 0600)).To(Succeed())
+			bat := authTransport{tokenFile: tokenFilePath, Transport: noopTransport}
+
+			req, _ := http.NewRequest(http.MethodGet, "https://example.com/api", nil)
+			_, err := bat.RoundTrip(req)
+			Expect(err).To(BeNil())
+			Expect(req.Header.Get("Authorization")).To(Equal("Bearer my-token"))
+		})
+
+		It("returns error when token file does not exist", func() {
+			bat := authTransport{tokenFile: "/nonexistent/token", Transport: noopTransport}
+			req, _ := http.NewRequest(http.MethodGet, "https://example.com/api", nil)
+			_, err := bat.RoundTrip(req)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to read token file"))
+		})
+
+		It("does not set Authorization when token file is empty", func() {
+			Expect(os.WriteFile(tokenFilePath, []byte(""), 0600)).To(Succeed())
+			bat := authTransport{tokenFile: tokenFilePath, Transport: noopTransport}
+
+			req, _ := http.NewRequest(http.MethodGet, "https://example.com/api", nil)
+			_, err := bat.RoundTrip(req)
+			Expect(err).To(BeNil())
+			Expect(req.Header.Get("Authorization")).To(Equal(""))
+		})
+
+		It("tokenFile takes precedence over static token", func() {
+			Expect(os.WriteFile(tokenFilePath, []byte("file-token"), 0600)).To(Succeed())
+			bat := authTransport{token: "static-token", tokenFile: tokenFilePath, Transport: noopTransport}
+
+			req, _ := http.NewRequest(http.MethodGet, "https://example.com/api", nil)
+			_, err := bat.RoundTrip(req)
+			Expect(err).To(BeNil())
+			Expect(req.Header.Get("Authorization")).To(Equal("Bearer file-token"))
 		})
 	})
 

--- a/prometheus/test_assets_test.go
+++ b/prometheus/test_assets_test.go
@@ -3,6 +3,7 @@ package prometheus
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/prometheus/common/model"
@@ -10,6 +11,12 @@ import (
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/stretchr/testify/mock"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 type flag int
 

--- a/prometheus/types.go
+++ b/prometheus/types.go
@@ -43,6 +43,7 @@ type Prometheus struct {
 type authTransport struct {
 	Transport http.RoundTripper
 	token     string
+	tokenFile string
 	username  string
 	password  string
 }


### PR DESCRIPTION
  ---
  Type of change

  - [ ] Refactor
  - [x] New feature
  - [ ] Bug fix
  - [ ] Optimization
  - [ ] Documentation Update

  Description

  When using kube-burner for long-running workloads (>1 hour), the Prometheus bearer token can expire
  mid-run, causing 401 errors. The token is set once at client creation and never refreshed.

  This PR adds a NewClientWithTokenFile constructor that accepts a file path instead of a static token
  string. The authTransport.RoundTrip re-reads the token from the file on every HTTP request, allowing
  an external process (cron job, sidecar script) to rotate the token without restarting the workload.

  Key design decisions:
  - NewClient signature and behavior are completely unchanged — fully backward-compatible
  - Shared logic is extracted into an internal newClient helper to avoid code duplication
  - Token file contents are trimmed of whitespace/newlines to handle common shell output (e.g. echo,
  gcloud auth print-access-token > file)

  Related Tickets & Documents

  - Related kube-burner PR: https://github.com/kube-burner/kube-burner/pull/1286

  Checklist before requesting a review

  - [x] I have performed a self-review of my code.
  - [x] If it is a core feature, I have added thorough tests.

  Testing

  System Under Test: authTransport.RoundTrip with tokenFile field set, tested via Ginkgo unit tests.

  Steps to verify:
  1. Run go test ./prometheus/... -v — all 15 tests pass (10 existing + 5 new)
  2. New test cases cover:
    - Token refresh: write token-v1 to file, verify header, overwrite with token-v2, verify updated
  header
    - Whitespace trimming: token with spaces/newlines is cleaned
    - Missing file: returns clear error
    - Empty file: no Authorization header set
    - Precedence: tokenFile overwrites static token when both set

  Manual validation: Built kube-burner with this go-commons change, tested against GCP Managed
  Prometheus with tokenFile pointing to a gcloud auth print-access-token output — successfully
  authenticated and scraped metrics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for authenticating Prometheus requests with a bearer token read from a file.
  * Tokens are refreshed on each request, with whitespace removed automatically.
  * File-based tokens take precedence over static authorization credentials.

* **Bug Fixes**
  * Missing token files now return a clear error.
  * Empty token files continue to support requests without overriding existing authorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->